### PR TITLE
Delete customer check orders bak

### DIFF
--- a/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerControllerTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerControllerTests.cs
@@ -145,7 +145,7 @@ namespace ThjonustukerfiTests.Tests
 
             //* Assert
             Assert.IsNotNull(response);
-            Assert.AreEqual(204, response.StatusCode);
+            Assert.AreEqual(StatusCodes.Status204NoContent, response.StatusCode);
         }
 
         [TestMethod]
@@ -166,8 +166,6 @@ namespace ThjonustukerfiTests.Tests
             Assert.IsInstanceOfType(response.Value as List<OrderDTO>, typeof(List<OrderDTO>));
             Assert.IsTrue((response.Value as List<OrderDTO>).Any());
         }
-
-        
 
         [TestMethod]
         public void GetCustomers_should_return_200OK_and_a_list_of_CustomerDto()
@@ -200,6 +198,24 @@ namespace ThjonustukerfiTests.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(200, response.StatusCode);
             Assert.AreEqual(responseValue.Count, retDTO.Count);
+        }
+
+        [TestMethod]
+        public void DeleteCustomerByIdAndOrders_should_respond_with_NoContent()
+        {
+            //* Arrange
+            // mock
+            _customerServiceMock.Setup(method => method.DeleteCustomerByIdAndOrders(It.IsAny<long>())).Verifiable();
+
+            // create controller
+            _customerController = new CustomerController(_customerServiceMock.Object);
+
+            //* Act
+            var response = _customerController.DeleteCustomerByIdAndOrders(1) as NoContentResult;
+
+            //* Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(StatusCodes.Status204NoContent, response.StatusCode);
         }
 
         //*         Helper functions         *//

--- a/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerControllerTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerControllerTests.cs
@@ -132,7 +132,7 @@ namespace ThjonustukerfiTests.Tests
                 Id = id,
                 Name = "Siggi Biggi"
             };
-            _customerServiceMock.Setup(method => method.DeleteCustomerById(id));
+            _customerServiceMock.Setup(method => method.DeleteCustomerById(id)).Returns(new List<OrderDTO>());
 
             // Creat contoller
             _customerController = new CustomerController(_customerServiceMock.Object);

--- a/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerServiceTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerServiceTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using ThjonustukerfiWebAPI.Models.DTOs;
@@ -122,6 +124,88 @@ namespace ThjonustukerfiTests.Tests
             //* Assert
             Assert.IsNotNull(returnvalue);
             Assert.AreEqual(returnvalue, retDTO);
+        }
+
+        [TestMethod]
+        public void DeleteCustomerById_should_return_a_OrderDTO_list_of_active_orders()
+        {
+            //* Arrange
+            // mock (do not need to mock customer repo here, since it should not call it)
+            _orderRepoMock.Setup(method => method.GetActiveOrdersByCustomerId(It.IsAny<long>())).Returns(CreateOrderDTOList());
+
+            // Create service
+            _customerService = new CustomerService(_customerRepoMock.Object, _orderRepoMock.Object);
+
+            //* Act
+            var returnValue = _customerService.DeleteCustomerById(1);
+
+            //* Assert
+            Assert.IsNotNull(returnValue);
+            Assert.IsInstanceOfType(returnValue, typeof(List<OrderDTO>));
+            Assert.IsTrue(returnValue.Any());
+        }
+
+        [TestMethod]
+        public void DeleteCustomerById_should_return_an_empty_OrderDTO_list_of_active_orders()
+        {
+            //* Arrange
+            // mock
+            _orderRepoMock.Setup(method => method.GetActiveOrdersByCustomerId(It.IsAny<long>())).Returns(new List<OrderDTO>());
+            _customerRepoMock.Setup(method => method.DeleteCustomerById(It.IsAny<long>())).Verifiable();
+
+            // Create service
+            _customerService = new CustomerService(_customerRepoMock.Object, _orderRepoMock.Object);
+
+            //* Act
+            var returnValue = _customerService.DeleteCustomerById(1);
+
+            //* Assert
+            Assert.IsNotNull(returnValue);
+            Assert.IsInstanceOfType(returnValue, typeof(List<OrderDTO>));
+            Assert.IsFalse(returnValue.Any());
+        }
+
+        //*         Helper functions         *//
+        /// <summary>Creates a list of order DTO for testing</summary>
+        private List<OrderDTO> CreateOrderDTOList()
+        {
+            return new List<OrderDTO>()
+            {
+                new OrderDTO
+                {
+                Customer = "Kalli Valli",
+                Barcode = "0100001111",
+                Items = new List<ItemDTO>()
+                    {
+                        new ItemDTO()
+                        {
+                            Id = 1,
+                            Type = "Ysa bitar",
+                            Service = "Birkireyk"
+                        }
+                    },
+                    DateCreated = DateTime.Now,
+                    DateModified = DateTime.MinValue,
+                    DateCompleted = DateTime.MaxValue
+                },
+                new OrderDTO
+                {
+                Customer = "Harpa Varta",
+                Barcode = "0100001111",
+                Items = new List<ItemDTO>()
+                    {
+                        new ItemDTO()
+                        {
+                            Id = 1,
+                            Type = "Lax bitar",
+                            Service = "Birkireyk"
+                        }
+                    },
+                    DateCreated = DateTime.Now,
+                    DateModified = DateTime.MinValue,
+                    DateCompleted = DateTime.MaxValue
+                }
+            };
         }
     }
 }

--- a/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerServiceTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerServiceTests.cs
@@ -14,12 +14,14 @@ namespace ThjonustukerfiTests.Tests
     {
         private ICustomerService _customerService;
         private Mock<ICustomerRepo> _customerRepoMock;
+        private Mock<IOrderRepo> _orderRepoMock;
 
         // This method is excecuted before each test
         [TestInitialize]
         public void Initialize()
         {
             _customerRepoMock = new Mock<ICustomerRepo>();
+            _orderRepoMock = new Mock<IOrderRepo>();
         }
 
         [TestMethod]
@@ -43,7 +45,7 @@ namespace ThjonustukerfiTests.Tests
             _customerRepoMock.Setup(method => method.CreateCustomer(inp)).Returns(mockCustomerDTO);
 
             // Craete service
-            _customerService = new CustomerService(_customerRepoMock.Object);
+            _customerService = new CustomerService(_customerRepoMock.Object, _orderRepoMock.Object);
 
             //* Act
             var customerDTOReturn = _customerService.CreateCustomer(inp);
@@ -75,7 +77,7 @@ namespace ThjonustukerfiTests.Tests
             _customerRepoMock.Setup(method => method.GetCustomerById(id)).Returns(mockCustomerDetailsDTO);
 
             // Create service
-            _customerService = new CustomerService(_customerRepoMock.Object);
+            _customerService = new CustomerService(_customerRepoMock.Object, _orderRepoMock.Object);
 
             //* Act
             var customerDetailsDTO = _customerService.GetCustomerById(id);
@@ -112,7 +114,7 @@ namespace ThjonustukerfiTests.Tests
             _customerRepoMock.Setup(method => method.GetAllCustomers()).Returns(retDTO);
 
             // Create service
-            _customerService = new CustomerService(_customerRepoMock.Object);
+            _customerService = new CustomerService(_customerRepoMock.Object, _orderRepoMock.Object);
 
             //* Act
             var returnvalue = _customerService.GetAllCustomers();

--- a/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerServiceTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerServiceTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using ThjonustukerfiWebAPI.Models.DTOs;
+using ThjonustukerfiWebAPI.Models.Exceptions;
 using ThjonustukerfiWebAPI.Models.InputModels;
 using ThjonustukerfiWebAPI.Repositories.Interfaces;
 using ThjonustukerfiWebAPI.Services.Implementations;
@@ -163,6 +164,20 @@ namespace ThjonustukerfiTests.Tests
             Assert.IsNotNull(returnValue);
             Assert.IsInstanceOfType(returnValue, typeof(List<OrderDTO>));
             Assert.IsFalse(returnValue.Any());
+        }
+
+        [TestMethod]
+        public void DeleteCustomerByIdAndOrders_should_throw_NotFoundException()
+        {
+            //* Arrange
+            // mock
+            _customerRepoMock.Setup(method => method.CustomerExists(It.IsAny<long>())).Returns(false);
+
+            // Create service
+            _customerService = new CustomerService(_customerRepoMock.Object, _orderRepoMock.Object);
+
+            //* Act and Assert
+            Assert.ThrowsException<NotFoundException>(() => _customerService.DeleteCustomerByIdAndOrders(1));
         }
 
         //*         Helper functions         *//

--- a/Bakendi/ThjonustukerfiTests/Tests/Order/OrderRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Order/OrderRepoTests.cs
@@ -12,6 +12,7 @@ using ThjonustukerfiWebAPI.Models.InputModels;
 using ThjonustukerfiWebAPI.Models.Exceptions;
 using ThjonustukerfiWebAPI.Repositories.Implementations;
 using ThjonustukerfiWebAPI.Models.Entities;
+using ThjonustukerfiWebAPI.Repositories.Interfaces;
 
 namespace ThjonustukerfiTests.Tests
 {
@@ -238,6 +239,27 @@ namespace ThjonustukerfiTests.Tests
 
                 //* Act and Assert
                 Assert.ThrowsException<NotFoundException>(() => orderRepo.CreateOrder(inp));
+            }
+        }
+
+        [TestMethod]
+        public void GetActiveOrdersByCustomerId_should_retrieve_correct_order()
+        {
+            //* Arrange
+            long customerId = 50;
+            long orderIdExpected = 100;
+            
+            // This order was created in the build database test. This person should only have this one order
+            using(var mockContext = new DataContext(_options))
+            {
+                IOrderRepo orderRepo = new OrderRepo(mockContext, _mapper);
+
+                //* Act
+                var activeList = orderRepo.GetActiveOrdersByCustomerId(customerId);
+
+                Assert.IsNotNull(activeList);
+                Assert.AreEqual(1, activeList.Count);
+                Assert.AreEqual(orderIdExpected, activeList[0].Id);
             }
         }
 

--- a/Bakendi/ThjonustukerfiTests/Tests/Order/OrderServiceTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Order/OrderServiceTests.cs
@@ -163,6 +163,7 @@ namespace ThjonustukerfiTests.Tests
             Assert.IsInstanceOfType(retVal, typeof(OrderDTO));
         }
 
+        /// <summary>Creates a list of order DTO for testing</summary>
         private List<OrderDTO> CreateOrderDTOList()
         {
             return new List<OrderDTO>()

--- a/Bakendi/ThjonustukerfiWebAPI/Controllers/CustomerController.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Controllers/CustomerController.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ThjonustukerfiWebAPI.Models.InputModels;
@@ -91,9 +92,12 @@ namespace ThjonustukerfiWebAPI.Controllers
         [HttpDelete]
         public IActionResult DeleteCustomerById(long id)
         {
-            _customerService.DeleteCustomerById(id);
+            // Checks if the customer has any active oders, only deletes if no orders are active
+            var activeOrders = _customerService.DeleteCustomerById(id);
 
-            return NoContent();
+            if(activeOrders.Any()) { return Conflict(activeOrders); }
+
+            return NoContent(); // not done
         }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Controllers/CustomerController.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Controllers/CustomerController.cs
@@ -101,5 +101,20 @@ namespace ThjonustukerfiWebAPI.Controllers
 
             return NoContent();
         }
+
+        /// <summary>Deletes a customer and removes all orders that are active with that customer as well</summary>
+        /// <returns>No Content</returns>
+        /// <response code="204">Customer successfully deleted</response>
+        /// <response code="404">Customer with the given ID was not found</response>
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [Route("{id:int}/confirm")]
+        [HttpDelete]
+        public IActionResult DeleteCustomerByIdAndOrders(long id)
+        {
+            _customerService.DeleteCustomerByIdAndOrders(id);
+
+            return NoContent();
+        }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Controllers/CustomerController.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Controllers/CustomerController.cs
@@ -86,8 +86,10 @@ namespace ThjonustukerfiWebAPI.Controllers
         /// <returns>Returns no content</returns>
         /// <response code="204">Customer successfully deleted</response>
         /// <response code="404">Customer with the given ID was not found</response>
+        /// <response code="409">Customer has active orders, no changes done and active orders are returned</response>
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         [Route("{id:int}")]
         [HttpDelete]
         public IActionResult DeleteCustomerById(long id)
@@ -97,7 +99,7 @@ namespace ThjonustukerfiWebAPI.Controllers
 
             if(activeOrders.Any()) { return Conflict(activeOrders); }
 
-            return NoContent(); // not done
+            return NoContent();
         }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Interfaces/IOrderRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Interfaces/IOrderRepo.cs
@@ -30,5 +30,9 @@ namespace ThjonustukerfiWebAPI.Repositories.Interfaces
         /// <summary>Finds ID of order with the given barcode.</summary>
         /// <returns>The orders ID</returns>
         long SearchOrder(string barcode);
+
+        /// <summary>Gets a list of all active orders with the customer</summary>
+        /// <returns>A list of active orders, empty if no orders exist that are active</returns>
+        List<OrderDTO> GetActiveOrdersByCustomerId(long customerID);
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Services/Implementations/CustomerService.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Services/Implementations/CustomerService.cs
@@ -1,4 +1,6 @@
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using ThjonustukerfiWebAPI.Models.DTOs;
 using ThjonustukerfiWebAPI.Models.InputModels;
 using ThjonustukerfiWebAPI.Repositories.Interfaces;
@@ -9,14 +11,24 @@ namespace ThjonustukerfiWebAPI.Services.Implementations
     public class CustomerService : ICustomerService
     {
         private ICustomerRepo _customerRepo;
-        public CustomerService(ICustomerRepo customerRepo)
+        private IOrderRepo _orderRepo;
+        public CustomerService(ICustomerRepo customerRepo, IOrderRepo orderRepo)
         {
             _customerRepo = customerRepo;
+            _orderRepo = orderRepo;
         }
         public CustomerDTO CreateCustomer(CustomerInputModel customer) => _customerRepo.CreateCustomer(customer);
         public CustomerDetailsDTO GetCustomerById(long id) => _customerRepo.GetCustomerById(id);
         public void UpdateCustomerDetails(CustomerInputModel customer, long id) => _customerRepo.UpdateCustomerDetails(customer, id);
-        public void DeleteCustomerById(long id) => _customerRepo.DeleteCustomerById(id);
+        public List<OrderDTO> DeleteCustomerById(long id)
+        {
+            List<OrderDTO> activeOrders = _orderRepo.GetActiveOrdersByCustomerId(id);
+
+            //TODO: Archive orders that are done, but not archived yet before deleting customer connection
+            if(!activeOrders.Any()) { _customerRepo.DeleteCustomerById(id); }
+
+            return activeOrders;
+        }
         public IEnumerable GetAllCustomers() => _customerRepo.GetAllCustomers();
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Services/Implementations/CustomerService.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Services/Implementations/CustomerService.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using ThjonustukerfiWebAPI.Models.DTOs;
+using ThjonustukerfiWebAPI.Models.Exceptions;
 using ThjonustukerfiWebAPI.Models.InputModels;
 using ThjonustukerfiWebAPI.Repositories.Interfaces;
 using ThjonustukerfiWebAPI.Services.Interfaces;
@@ -22,7 +23,7 @@ namespace ThjonustukerfiWebAPI.Services.Implementations
         public void UpdateCustomerDetails(CustomerInputModel customer, long id) => _customerRepo.UpdateCustomerDetails(customer, id);
         public List<OrderDTO> DeleteCustomerById(long id)
         {
-            List<OrderDTO> activeOrders = _orderRepo.GetActiveOrdersByCustomerId(id);
+            List<OrderDTO> activeOrders = _orderRepo.GetActiveOrdersByCustomerId(id);   // doesn't need to throw any exception, will just return an empty list if none is found
 
             //TODO: Archive orders that are done, but not archived yet before deleting customer connection
             if(!activeOrders.Any()) { _customerRepo.DeleteCustomerById(id); }
@@ -30,5 +31,26 @@ namespace ThjonustukerfiWebAPI.Services.Implementations
             return activeOrders;
         }
         public IEnumerable GetAllCustomers() => _customerRepo.GetAllCustomers();
+
+        public void DeleteCustomerByIdAndOrders(long customerId)
+        {
+            // Check if the customer exists
+            if(!_customerRepo.CustomerExists(customerId)) { throw new NotFoundException($"Customer with ID {customerId} was not found."); }
+
+            // Get active orders
+            List<OrderDTO> activeOrders = _orderRepo.GetActiveOrdersByCustomerId(customerId);
+
+            // If any active orders, delete them
+            if(activeOrders.Any())
+            {
+                foreach (var order in activeOrders)
+                {
+                    _orderRepo.DeleteByOrderId(order.Id);
+                }
+            }
+
+            // After deleting orders (if any) delete the customer
+            _customerRepo.DeleteCustomerById(customerId);
+        }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Services/Interfaces/ICustomerService.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Services/Interfaces/ICustomerService.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 using ThjonustukerfiWebAPI.Models.DTOs;
 using ThjonustukerfiWebAPI.Models.InputModels;
 
@@ -18,7 +19,8 @@ namespace ThjonustukerfiWebAPI.Services.Interfaces
         void UpdateCustomerDetails(CustomerInputModel customer, long id);
 
         /// <summary>Deletes a customer with the given ID.</summary>
-        void DeleteCustomerById(long id);
+        /// <returns>An empty list if person is deleted, else list of active orders for that customer.</returns>
+        List<OrderDTO> DeleteCustomerById(long id);
 
         /// <summary>Gets all customers.</summary>
         /// <returns>A list of all customers.</returns>

--- a/Bakendi/ThjonustukerfiWebAPI/Services/Interfaces/ICustomerService.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Services/Interfaces/ICustomerService.cs
@@ -25,5 +25,8 @@ namespace ThjonustukerfiWebAPI.Services.Interfaces
         /// <summary>Gets all customers.</summary>
         /// <returns>A list of all customers.</returns>
         IEnumerable GetAllCustomers();
+
+        /// <summary>Deletes customer and all of their active orders</summary>
+        void DeleteCustomerByIdAndOrders(long customerId);
     }
 }


### PR DESCRIPTION
Delete customer will now check for active orders. If their are any, it will respond with Conflict (409) with the orders that are active.

You can also "override" this by deleting customer with /confirm at the end of the endpoint. This will delete all active orders on that customer as well as the customer itself.

See the swagger docs for more details! :)