### PR TITLE
Adding category table bak

### DIFF
--- a/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerControllerTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerControllerTests.cs
@@ -233,7 +233,7 @@ namespace ThjonustukerfiTests.Tests
                         new ItemDTO()
                         {
                             Id = 1,
-                            Type = "Ysa bitar",
+                            Category = "Ysa bitar",
                             Service = "Birkireyk"
                         }
                     },
@@ -250,7 +250,7 @@ namespace ThjonustukerfiTests.Tests
                         new ItemDTO()
                         {
                             Id = 1,
-                            Type = "Lax bitar",
+                            Category = "Lax bitar",
                             Service = "Birkireyk"
                         }
                     },

--- a/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerServiceTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Customer/CustomerServiceTests.cs
@@ -195,7 +195,7 @@ namespace ThjonustukerfiTests.Tests
                         new ItemDTO()
                         {
                             Id = 1,
-                            Type = "Ysa bitar",
+                            Category = "Ysa bitar",
                             Service = "Birkireyk"
                         }
                     },
@@ -212,7 +212,7 @@ namespace ThjonustukerfiTests.Tests
                         new ItemDTO()
                         {
                             Id = 1,
-                            Type = "Lax bitar",
+                            Category = "Lax bitar",
                             Service = "Birkireyk"
                         }
                     },

--- a/Bakendi/ThjonustukerfiTests/Tests/Info/InfoControllerTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Info/InfoControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -88,6 +89,32 @@ namespace ThjonustukerfiTests.Tests.Info
             Assert.IsNotNull(responseValue);
             Assert.AreEqual(200, response.StatusCode);
             Assert.AreEqual(retDTO, responseValue);
+        }
+
+        [TestMethod]
+        public void GetCategories_should_return_200OK_and_a_list_of_states()
+        {
+            //* Arrange
+            var retDTO = new List<CategoryDTO>()
+            {
+                new CategoryDTO { Id = 1, Name = "Lax" },
+                new CategoryDTO { Id = 2, Name = "Silungur" }
+            };
+
+            //Mock method
+            _infoServiceMock.Setup(method => method.GetCategories()).Returns(retDTO);
+
+            // Create controller
+            _infoController = new InfoController(_infoServiceMock.Object);
+
+            //* Act
+            var response = _infoController.GetCategories() as OkObjectResult;
+
+            //* Assert
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.Value);
+            Assert.AreEqual(StatusCodes.Status200OK, response.StatusCode);
+            Assert.IsInstanceOfType(response.Value as List<CategoryDTO>, typeof(List<CategoryDTO>));
         }
     }
 }

--- a/Bakendi/ThjonustukerfiTests/Tests/Info/InfoRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Info/InfoRepoTests.cs
@@ -47,11 +47,12 @@ namespace ThjonustukerfiTests.Tests.Info
                 var infoRepo = new InfoRepo(mockContext, _mapper);
 
                 //* Act
-                List<ServiceDTO> result = infoRepo.GetServices() as List<ServiceDTO>;   // convert IEnumberable to List
+                var result = infoRepo.GetServices();
 
                 //* Assert
                 Assert.IsNotNull(result);
-                Assert.AreEqual(0, result.Count);
+                Assert.IsInstanceOfType(result, typeof(IEnumerable<ServiceDTO>));
+                Assert.AreEqual(0, result.Count());
             }
         }
 
@@ -64,11 +65,30 @@ namespace ThjonustukerfiTests.Tests.Info
                 var infoRepo = new InfoRepo(mockContext, _mapper);
 
                 //* Act
-                List<StateDTO> result = infoRepo.GetStates() as List<StateDTO>; // convert IEnumberable to List
+                var result = infoRepo.GetStates();
 
                 //* Assert
                 Assert.IsNotNull(result);
-                Assert.AreEqual(0, result.Count);
+                Assert.IsInstanceOfType(result, typeof(IEnumerable<StateDTO>));
+                Assert.AreEqual(0, result.Count());
+            }
+        }
+
+        [TestMethod]
+        public void GetCategories_should_return_an_empty_list()
+        {
+            //* Arrange
+            using(var mockContext = new DataContext(_options))
+            {
+                var infoRepo = new InfoRepo(mockContext, _mapper);
+
+                //* Act
+                var result = infoRepo.GetCategories();
+
+                //* Assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(IEnumerable<CategoryDTO>));
+                Assert.AreEqual(0, result.Count());
             }
         }
 
@@ -127,6 +147,26 @@ namespace ThjonustukerfiTests.Tests.Info
             }
         }
 
+        [TestMethod]
+        public void GetCategories_should_return_a_list_of_CategoryDTO_with_correct_size()
+        {
+            //* Arrange
+            using(var mockContext = new DataContext(_options))
+            {
+                // Setup repo
+                var infoRepo = new InfoRepo(mockContext, _mapper);
+                var DbTableSize = mockContext.Category.Count();
+
+                //* Act
+                var result = infoRepo.GetCategories();
+
+                //* Assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(IEnumerable<CategoryDTO>));
+                Assert.AreEqual(DbTableSize, result.Count());
+            }
+        }
+
         //**********     Helper functions     **********//
         private void FillDatabase(DataContext mockContext)
         {
@@ -146,9 +186,18 @@ namespace ThjonustukerfiTests.Tests.Info
                 new State() {Name = "Sótt", Id = 5}
             };
 
+            var categories = new List<Category>()
+            {
+                // Categories for Reykofninn
+                new Category() {Name = "Lax", Id = 1},
+                new Category() {Name = "Silungur", Id = 2},
+                new Category() {Name = "Lambakjöt", Id = 3}
+            };
+
             // Adding services to the in memory database and saving it
             mockContext.Service.AddRange(services);
             mockContext.State.AddRange(states);
+            mockContext.Category.AddRange(categories);
             mockContext.SaveChanges();
         }
     }

--- a/Bakendi/ThjonustukerfiTests/Tests/Info/InfoServiceTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Info/InfoServiceTests.cs
@@ -48,6 +48,7 @@ namespace ThjonustukerfiTests.Tests.Info
 
             //* Assert
             Assert.IsNotNull(returnValue);
+            Assert.IsInstanceOfType(returnValue, typeof(List<ServiceDTO>));
             Assert.AreEqual(retDTO, returnValue);
         }
 
@@ -79,6 +80,31 @@ namespace ThjonustukerfiTests.Tests.Info
 
             //* Assert
             Assert.IsNotNull(returnValue);
+            Assert.IsInstanceOfType(returnValue, typeof(List<StateDTO>));
+            Assert.AreEqual(retDTO, returnValue);
+        }
+
+        [TestMethod]
+        public void GetCategories_should_return_a_list_of_CategoryDTO()
+        {
+            //* Arrange
+            var retDTO = new List<CategoryDTO>()
+            {
+                new CategoryDTO { Id = 1, Name = "Lax" },
+                new CategoryDTO { Id = 2, Name = "Silungur" }
+            };
+            // mock method
+            _infoRepoMock.Setup(method => method.GetCategories()).Returns(retDTO);
+
+            // Create service
+            _infoService = new InfoService(_infoRepoMock.Object);
+
+            //* Act
+            var returnValue = _infoService.GetCategories();
+
+            //* Assert
+            Assert.IsNotNull(returnValue);
+            Assert.IsInstanceOfType(returnValue, typeof(List<CategoryDTO>));
             Assert.AreEqual(retDTO, returnValue);
         }
     }

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemControllerTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemControllerTests.cs
@@ -29,7 +29,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             {
                 Id = 1,
                 OrderId = 1,
-                Type = "Test",
+                Category = "Test",
                 State = "Í vinnslu",
                 DateModified = DateTime.Now
             };
@@ -53,7 +53,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
         {
             var item = new EditItemInput
             {
-                Type = "Hello"
+                CategoryId = 1
             };
 
             // setup and create controller
@@ -97,7 +97,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             {
                 Id = itemID,
                 OrderId = 2,
-                Type = "bitar",
+                Category = "bitar",
                 State = "Í vinnslu",
                 DateModified = DateTime.Now
             };

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemRepoTests.cs
@@ -108,7 +108,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
         public void EditItem_should_edit_correct_items()
         {
             //* Arrange
-            string type = "This is not a fish";
+            long categoryId = 1;
             long stateID = 3;
             long serviceID = 2;
             long orderID = 100;
@@ -116,7 +116,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             long orderChange = 101;
             var itemInput = new EditItemInput
             {
-                Type = type,
+                CategoryId = categoryId,
                 StateId = stateID,
                 ServiceID = serviceID,
                 OrderId = orderChange
@@ -142,7 +142,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
                 var oldItemEntity = new Item()  // Copying item values (not the reference to the object)
                 {
                     Id = trackedEntity.Id,
-                    Type = trackedEntity.Type,
+                    CategoryId = trackedEntity.CategoryId,
                     StateId = trackedEntity.StateId,
                     ServiceId = trackedEntity.ServiceId,
                     Barcode = trackedEntity.Barcode,
@@ -175,7 +175,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
                 Assert.AreEqual(oldOrder2ListSize + 1, newOrder2ListSize);  // has been moved to other list
 
                 // Check that item properties have been updated correctly
-                Assert.AreEqual(type, changedItem.Type);
+                Assert.AreEqual(categoryId, changedItem.CategoryId);
                 Assert.AreEqual(stateID, changedItem.StateId);
                 Assert.AreEqual(serviceID, changedItem.ServiceId);
                 Assert.AreEqual(orderChange, mockContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == changedItem.Id).OrderId);
@@ -191,6 +191,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             var input2 = new EditItemInput { StateId = -1 };
             var input3 = new EditItemInput { ServiceID = -1 };
             var input4 = new EditItemInput { OrderId = -1 };
+            var input5 = new EditItemInput { CategoryId = -1 };
 
             long itemID = 2;
 
@@ -203,6 +204,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
                 Assert.ThrowsException<NotFoundException>(() => itemRepo.EditItem(input2, itemID));
                 Assert.ThrowsException<NotFoundException>(() => itemRepo.EditItem(input3, itemID));
                 Assert.ThrowsException<NotFoundException>(() => itemRepo.EditItem(input4, itemID));
+                Assert.ThrowsException<NotFoundException>(() => itemRepo.EditItem(input5, itemID));
             }
         }
 
@@ -431,7 +433,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
                 new Item
                 {
                     Id = 1,
-                    Type = "Ysa bitar",
+                    CategoryId = 1,
                     StateId = 1,
                     ServiceId = 1,
                     Barcode = "50500001",
@@ -442,7 +444,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
                 new Item
                 {
                     Id = 2,
-                    Type = "Lax heil flok",
+                    CategoryId = 2,
                     StateId = 1,
                     ServiceId = 1,
                     Barcode = "50500002",
@@ -519,6 +521,14 @@ namespace ThjonustukerfiTests.Tests.ItemTests
                 new State() {Name = "Sótt", Id = 5}
             };
 
+            // Adding Types
+            var categories = new List<Category>()
+            {
+                // states fyrir reykofninn
+                new Category() {Name = "Lax", Id = 1},
+                new Category() {Name = "Silungur", Id = 2}
+            };
+
             // Adding all entities to the in memory database
             mockContext.Order.AddRange(orders);
             mockContext.Customer.AddRange(customers);
@@ -526,6 +536,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             mockContext.Item.AddRange(mockItems);
             mockContext.Service.AddRange(MockServiceList);
             mockContext.State.AddRange(states);
+            mockContext.Category.AddRange(categories);
             mockContext.SaveChanges();
             //! Building DB done
         }

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemRepoTests.cs
@@ -262,6 +262,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
                 var itemDTO = _mapper.Map<ItemStateDTO>(itemEntity);
                 itemDTO.OrderId = mockContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == itemEntity.Id).OrderId;
                 itemDTO.State = mockContext.State.FirstOrDefault(s => s.Id == itemEntity.StateId).Name;
+                itemDTO.Category = mockContext.Category.FirstOrDefault(c => c.Id == itemEntity.CategoryId).Name;
 
                 //* Act
                 var retVal = itemRepo.GetItemById(itemID);

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemServiceTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemServiceTests.cs
@@ -29,7 +29,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             {
                 Id = itemID,
                 OrderId = 1,
-                Type = "Test",
+                Category = "Test",
                 State = "Í vinnslu",
                 DateModified = DateTime.Now
             };
@@ -59,7 +59,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             {
                 Id = itemID,
                 OrderId = 2,
-                Type = "bitar",
+                Category = "bitar",
                 State = "Í vinnslu",
                 DateModified = DateTime.Now
             };

--- a/Bakendi/ThjonustukerfiTests/Tests/Order/OrderControllerTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Order/OrderControllerTests.cs
@@ -33,7 +33,7 @@ namespace ThjonustukerfiTests.Tests
                 Items = new List<ItemInputModel>()
                 {
                     new ItemInputModel {
-                        Type = "Ysa"
+                        CategoryId = 1
                     }
                 }
             };
@@ -69,7 +69,7 @@ namespace ThjonustukerfiTests.Tests
                         new ItemDTO()
                         {
                             Id = 1,
-                            Type = "Ysa bitar",
+                            Category = "Ysa bitar",
                             Service = "Birkireyk"
                         }
                     },
@@ -101,7 +101,7 @@ namespace ThjonustukerfiTests.Tests
                 Items = new List<ItemInputModel>()
                 {
                     new ItemInputModel {
-                        Type = "Ysa"
+                        CategoryId = 1
                     }
                 }
             };
@@ -232,7 +232,7 @@ namespace ThjonustukerfiTests.Tests
                         new ItemDTO()
                         {
                             Id = 1,
-                            Type = "Ysa bitar",
+                            Category = "Ysa bitar",
                             Service = "Birkireyk"
                         }
                     },
@@ -249,7 +249,7 @@ namespace ThjonustukerfiTests.Tests
                         new ItemDTO()
                         {
                             Id = 1,
-                            Type = "Lax bitar",
+                            Category = "Lax bitar",
                             Service = "Birkireyk"
                         }
                     },

--- a/Bakendi/ThjonustukerfiTests/Tests/Order/OrderRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Order/OrderRepoTests.cs
@@ -90,7 +90,6 @@ namespace ThjonustukerfiTests.Tests
             using (var mockContext = new DataContext(_options))
             {
                 //* Arrange
-                string serviceName = "Birkireyking";
                 long orderId = 100;
                 string customerName = "Viggi Siggi";
                 string OrderBarCode = "20200001";
@@ -100,11 +99,15 @@ namespace ThjonustukerfiTests.Tests
 
                 // Create a list that should be the same as the list returned in OrderDTO
                 var itemListDTO = new List<ItemDTO>();
-                var mockItems = mockContext.Item.ToList();
-                foreach (var item in mockItems)
+                var itemOrderConnection = mockContext.ItemOrderConnection.Where(ioc => ioc.OrderId == orderId).ToList();
+                
+                foreach (var item in itemOrderConnection)
                 {
-                    var add = _mapper.Map<ItemDTO>(item);
-                    add.Service = serviceName;
+                    var entity = mockContext.Item.FirstOrDefault(i => i.Id == item.ItemId);
+                    var add = _mapper.Map<ItemDTO>(entity);
+                    add.Service = mockContext.Service.FirstOrDefault(s => s.Id == entity.ServiceId).Name;
+                    add.State = mockContext.State.FirstOrDefault(s => s.Id == entity.StateId).Name;
+                    add.Category = mockContext.Category.FirstOrDefault(c => c.Id == entity.CategoryId).Name;
                     itemListDTO.Add(add);
                 }
 
@@ -123,7 +126,7 @@ namespace ThjonustukerfiTests.Tests
 
                 // Asserting items in order
                 Assert.IsNotNull(orderDTO.Items);
-                Assert.AreEqual(orderDTO.Items.Count, mockItems.Count);
+                Assert.AreEqual(orderDTO.Items.Count, itemListDTO.Count);
                 Assert.AreEqual(orderDTO.Items[0], itemListDTO[0]);
                 Assert.AreEqual(orderDTO.Items[1], itemListDTO[1]);
             };

--- a/Bakendi/ThjonustukerfiTests/Tests/Order/OrderRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Order/OrderRepoTests.cs
@@ -153,12 +153,12 @@ namespace ThjonustukerfiTests.Tests
                 {
                     new ItemInputModel 
                     {
-                        Type = "Ysa",
+                        CategoryId = 1,
                         ServiceId = 1
                     },
                     new ItemInputModel 
                     {
-                        Type = "Lax",
+                        CategoryId = 2,
                         ServiceId = 1
                     }
                 }
@@ -196,9 +196,9 @@ namespace ThjonustukerfiTests.Tests
 
                 // Assert Item
                 Assert.AreEqual(mockContext.Item.Count(), itemDbSize + inp.Items.Count());
-                Assert.AreEqual(itemListDTO[0].Type, inp.Items[0].Type);
+                Assert.AreEqual(itemListDTO[0].CategoryId, inp.Items[0].CategoryId);
                 Assert.AreEqual(itemListDTO[0].ServiceId, inp.Items[0].ServiceId);
-                Assert.AreEqual(itemListDTO[1].Type, inp.Items[1].Type);
+                Assert.AreEqual(itemListDTO[1].CategoryId, inp.Items[1].CategoryId);
                 Assert.AreEqual(itemListDTO[1].ServiceId, inp.Items[1].ServiceId);
 
                 // Assert ItemOrderConnection
@@ -222,12 +222,12 @@ namespace ThjonustukerfiTests.Tests
                 {
                     new ItemInputModel 
                     {
-                        Type = "Ysa",
+                        CategoryId = 1,
                         ServiceId = -1
                     },
                     new ItemInputModel 
                     {
-                        Type = "Lax",
+                        CategoryId = 2,
                         ServiceId = 2
                     }
                 }
@@ -276,17 +276,17 @@ namespace ThjonustukerfiTests.Tests
                 {
                     new ItemInputModel 
                     {
-                        Type = "BREYTT",
+                        CategoryId = 1,
                         ServiceId = 2
                     },
                     new ItemInputModel 
                     {
-                        Type = "BREYTT",
+                        CategoryId = 1,
                         ServiceId = 3
                     },
                     new ItemInputModel 
                     {
-                        Type = "OGSTAEKKA",
+                        CategoryId = 1,
                         ServiceId = 4
                     }
                 }
@@ -327,9 +327,9 @@ namespace ThjonustukerfiTests.Tests
                 Assert.IsNotNull(newItemList);
                 Assert.AreEqual(newItemList.Count, oldItemList.Count + 1);      // list is going from two to three
                 // check type
-                Assert.AreEqual(newItemList[0].Type, orperInput.Items[0].Type);
-                Assert.AreEqual(newItemList[1].Type, orperInput.Items[1].Type);
-                Assert.AreEqual(newItemList[2].Type, orperInput.Items[2].Type);
+                Assert.AreEqual(newItemList[0].CategoryId, orperInput.Items[0].CategoryId);
+                Assert.AreEqual(newItemList[1].CategoryId, orperInput.Items[1].CategoryId);
+                Assert.AreEqual(newItemList[2].CategoryId, orperInput.Items[2].CategoryId);
                 // check service ID
                 Assert.AreEqual(newItemList[0].ServiceId, orperInput.Items[0].ServiceId);
                 Assert.AreEqual(newItemList[1].ServiceId, orperInput.Items[1].ServiceId);
@@ -350,7 +350,7 @@ namespace ThjonustukerfiTests.Tests
                 {
                     new ItemInputModel 
                     {
-                        Type = "MINNKA",
+                        CategoryId = 1,
                         ServiceId = 2
                     }
                 }
@@ -391,7 +391,7 @@ namespace ThjonustukerfiTests.Tests
                 Assert.IsNotNull(newItemList);
                 Assert.AreEqual(newItemList.Count, oldItemList.Count - 2);      // list is going from 3 to one
                 // check type
-                Assert.AreEqual(newItemList[0].Type, orperInput.Items[0].Type);
+                Assert.AreEqual(newItemList[0].CategoryId, orperInput.Items[0].CategoryId);
                 // check service ID
                 Assert.AreEqual(newItemList[0].ServiceId, orperInput.Items[0].ServiceId);
             }
@@ -464,27 +464,27 @@ namespace ThjonustukerfiTests.Tests
                 {
                     new ItemInputModel 
                     {
-                        Type = "STÆKKUN",
+                        CategoryId = 2,
                         ServiceId = 1
                     },
                     new ItemInputModel 
                     {
-                        Type = "STÆKKUN",
+                        CategoryId = 2,
                         ServiceId = 1
                     },
                     new ItemInputModel 
                     {
-                        Type = "STÆKKUN",
+                        CategoryId = 2,
                         ServiceId = 1
                     },
                     new ItemInputModel 
                     {
-                        Type = "STÆKKUN",
+                        CategoryId = 2,
                         ServiceId = 1
                     },
                     new ItemInputModel 
                     {
-                        Type = "STÆKKUN",
+                        CategoryId = 2,
                         ServiceId = 1
                     }
                 }
@@ -526,11 +526,11 @@ namespace ThjonustukerfiTests.Tests
                 Assert.IsNotNull(newItemList);
                 Assert.AreEqual(newItemList.Count, oldItemList.Count + 5);      // list is going from zero to five
                 // check type
-                Assert.AreEqual(newItemList[0].Type, "STÆKKUN");
-                Assert.AreEqual(newItemList[1].Type, "STÆKKUN");
-                Assert.AreEqual(newItemList[2].Type, "STÆKKUN");
-                Assert.AreEqual(newItemList[3].Type, "STÆKKUN");
-                Assert.AreEqual(newItemList[4].Type, "STÆKKUN");
+                Assert.AreEqual(newItemList[0].CategoryId, 2);
+                Assert.AreEqual(newItemList[1].CategoryId, 2);
+                Assert.AreEqual(newItemList[2].CategoryId, 2);
+                Assert.AreEqual(newItemList[3].CategoryId, 2);
+                Assert.AreEqual(newItemList[4].CategoryId, 2);
                 // check service ID
                 Assert.AreEqual(newItemList[0].ServiceId, (long)1);
                 Assert.AreEqual(newItemList[1].ServiceId, (long)1);
@@ -587,7 +587,7 @@ namespace ThjonustukerfiTests.Tests
                     oldItemsStates.Add(new Item()   // copying each variable rather than the reference of the objects
                     {
                         Id = entity.Id,
-                        Type = entity.Type,
+                        CategoryId = entity.CategoryId,
                         StateId = entity.StateId,
                         ServiceId = entity.ServiceId,
                         Barcode = entity.Barcode,
@@ -792,7 +792,7 @@ namespace ThjonustukerfiTests.Tests
                 new Item
                 {
                     Id = 1,
-                    Type = "Ysa bitar",
+                    CategoryId = 1,
                     StateId = 1,
                     ServiceId = 1,
                     Barcode = "50500001",
@@ -802,7 +802,7 @@ namespace ThjonustukerfiTests.Tests
                 new Item
                 {
                     Id = 2,
-                    Type = "Lax heil flok",
+                    CategoryId = 2,
                     StateId = 1,
                     ServiceId = 1,
                     Barcode = "50500002",
@@ -812,10 +812,12 @@ namespace ThjonustukerfiTests.Tests
             };
 
             // Adding service
-            Service mockService = new Service()
+            var mockServices = new List<Service>()
             {
-                Name = serviceName,
-                Id = 1
+                new Service() { Name = serviceName, Id = 1 },
+                new Service() { Name = "Taðreyking", Id = 2 },
+                new Service() { Name = "Viðarreyking", Id = 3 },
+                new Service() { Name = "Salt pækill", Id = 4 }
             };
 
             // Build a list of size 20, make it queryable for the database mock
@@ -855,13 +857,22 @@ namespace ThjonustukerfiTests.Tests
                 new State() {Name = "Sótt", Id = 5}
             };
 
+            // Adding categories
+            var categories = new List<Category>()
+            {
+                // Catagories for Reykofninn
+                new Category() {Name = "Lax", Id = 1},
+                new Category() {Name = "Silungur", Id = 2}
+            };
+
             // Adding all entities to the in memory database
             mockContext.Order.AddRange(orders);
             mockContext.Customer.AddRange(customers);
             mockContext.ItemOrderConnection.AddRange(mockIOConnect);
             mockContext.Item.AddRange(mockItems);
-            mockContext.Service.Add(mockService);
+            mockContext.Service.AddRange(mockServices);
             mockContext.State.AddRange(states);
+            mockContext.Category.AddRange(categories);
             mockContext.SaveChanges();
             //! Building DB done
         }

--- a/Bakendi/ThjonustukerfiTests/Tests/Order/OrderRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Order/OrderRepoTests.cs
@@ -270,7 +270,7 @@ namespace ThjonustukerfiTests.Tests
         public void UpdateOrder_should_update_order_correctly_and_itemlist_should_grow()
         {
             long orderID = 100;
-            long custId = 500;
+            long custId = 50;
             //* Arrange
             var orperInput = new OrderInputModel
             {
@@ -344,7 +344,7 @@ namespace ThjonustukerfiTests.Tests
         public void UpdateOrder_should_update_order_correctly_and_itemlist_should_shrink()
         {
             long orderID = 100;
-            long custId = 500;
+            long custId = 50;
             //* Arrange
             var orperInput = new OrderInputModel
             {
@@ -404,7 +404,7 @@ namespace ThjonustukerfiTests.Tests
         public void UpdateOrder_should_update_order_correctly_and_itemlist_should_be_empty()
         {
             long orderID = 100;
-            long custId = 500;
+            long custId = 50;
             //* Arrange
             var orperInput = new OrderInputModel
             {
@@ -453,7 +453,7 @@ namespace ThjonustukerfiTests.Tests
         public void UpdateOrder_should_update_order_correctly_and_itemlist_should_grow_to_five()
         {
             long orderID = 100;
-            long custId = 500;
+            long custId = 50;
             //* Arrange
             var clearItems = new OrderInputModel
             {
@@ -559,6 +559,7 @@ namespace ThjonustukerfiTests.Tests
 
                 //* Act then assert
                 Assert.ThrowsException<NotFoundException>(() => orderRepo.UpdateOrder(inp, -1));
+                Assert.ThrowsException<NotFoundException>(() => orderRepo.UpdateOrder(inp, 100));
             }
         }
 

--- a/Bakendi/ThjonustukerfiTests/Tests/Order/OrderServiceTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Order/OrderServiceTests.cs
@@ -36,7 +36,7 @@ namespace ThjonustukerfiTests.Tests
                 Items = new List<ItemInputModel>()
                 {
                     new ItemInputModel {
-                        Type = "Ysa"
+                        CategoryId = 1
                     }
                 }
             };
@@ -66,7 +66,7 @@ namespace ThjonustukerfiTests.Tests
                 Items = new List<ItemInputModel>()
                 {
                     new ItemInputModel {
-                        Type = "Ysa"
+                        CategoryId = 1
                     }
                 }
             };  
@@ -95,7 +95,7 @@ namespace ThjonustukerfiTests.Tests
                         new ItemDTO()
                         {
                             Id = 1,
-                            Type = "Ysa bitar",
+                            Category = "Ysa bitar",
                             Service = "Birkireyk"
                         }
                     },
@@ -177,7 +177,7 @@ namespace ThjonustukerfiTests.Tests
                         new ItemDTO()
                         {
                             Id = 1,
-                            Type = "Ysa bitar",
+                            Category = "Ysa bitar",
                             Service = "Birkireyk"
                         }
                     },
@@ -194,7 +194,7 @@ namespace ThjonustukerfiTests.Tests
                         new ItemDTO()
                         {
                             Id = 1,
-                            Type = "Lax bitar",
+                            Category = "Lax bitar",
                             Service = "Birkireyk"
                         }
                     },

--- a/Bakendi/ThjonustukerfiWebAPI/Configurations/SetupTables.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Configurations/SetupTables.cs
@@ -12,6 +12,7 @@ namespace ThjonustukerfiWebAPI.Configurations
         private List<Service> _services;
         private List<ServiceState> _serviceStates;
         private List<State> _states;
+        private List<Category> _categories;
 
         public SetupTables(DataContext context)
         {
@@ -25,6 +26,7 @@ namespace ThjonustukerfiWebAPI.Configurations
             var DB_Services = _dbContext.Set<Service>().ToList();
             var DB_ServiceStates = _dbContext.Set<ServiceState>().ToList();
             var DB_States = _dbContext.Set<State>().ToList();
+            var DB_Categories = _dbContext.Set<Category>().ToList();
 
             fillLists();
             bool change = false;
@@ -56,6 +58,15 @@ namespace ThjonustukerfiWebAPI.Configurations
                 change = true;
             }
 
+            // empty or not with all data
+            if(DB_Categories == null || DB_Categories.Count == 0 || DB_Categories.Count != _states.Count)
+            {
+                _categories.RemoveExisting(DB_Categories);
+                _dbContext.Category.AddRange(_categories);
+
+                change = true;
+            }
+
             if(change) { _dbContext.SaveChanges(); }
         }
 
@@ -67,7 +78,9 @@ namespace ThjonustukerfiWebAPI.Configurations
             {
                 // Birkireyking
                 new Service() {Name = "Birkireyking", Id = 1},
-                new Service() {Name = "Taðreyking", Id = 2}
+                new Service() {Name = "Taðreyking", Id = 2},
+                new Service() {Name = "ViðarReyking", Id = 3},
+                new Service() {Name = "Salt pækill", Id = 4}
             };
 
             //* Add Service states here
@@ -78,7 +91,28 @@ namespace ThjonustukerfiWebAPI.Configurations
                 new ServiceState() {Id = 2, ServiceId = 1, StateId = 2, Step = 2},
                 new ServiceState() {Id = 3, ServiceId = 1, StateId = 3, Step = 2},
                 new ServiceState() {Id = 4, ServiceId = 1, StateId = 4, Step = 2},
-                new ServiceState() {Id = 5, ServiceId = 1, StateId = 5, Step = 3}
+                new ServiceState() {Id = 5, ServiceId = 1, StateId = 5, Step = 3},
+
+                // Service state fyrir Taðreykingu
+                new ServiceState() {Id = 6, ServiceId = 2, StateId = 1, Step = 1},
+                new ServiceState() {Id = 7, ServiceId = 2, StateId = 2, Step = 2},
+                new ServiceState() {Id = 8, ServiceId = 2, StateId = 3, Step = 2},
+                new ServiceState() {Id = 9, ServiceId = 2, StateId = 4, Step = 2},
+                new ServiceState() {Id = 10, ServiceId = 2, StateId = 5, Step = 3},
+
+                // Service state fyrir viðarReykingu
+                new ServiceState() {Id = 11, ServiceId = 3, StateId = 1, Step = 1},
+                new ServiceState() {Id = 12, ServiceId = 3, StateId = 2, Step = 2},
+                new ServiceState() {Id = 13, ServiceId = 3, StateId = 3, Step = 2},
+                new ServiceState() {Id = 14, ServiceId = 3, StateId = 4, Step = 2},
+                new ServiceState() {Id = 15, ServiceId = 3, StateId = 5, Step = 3},
+
+                // Service state fyrir salt pækil
+                new ServiceState() {Id = 16, ServiceId = 4, StateId = 1, Step = 1},
+                new ServiceState() {Id = 17, ServiceId = 4, StateId = 2, Step = 2},
+                new ServiceState() {Id = 18, ServiceId = 4, StateId = 3, Step = 2},
+                new ServiceState() {Id = 19, ServiceId = 4, StateId = 4, Step = 2},
+                new ServiceState() {Id = 20, ServiceId = 4, StateId = 5, Step = 3}
             };
 
             //* Add states here
@@ -90,6 +124,15 @@ namespace ThjonustukerfiWebAPI.Configurations
                 new State() {Name = "Kælir 2", Id = 3},
                 new State() {Name = "Frystir", Id = 4},
                 new State() {Name = "Sótt", Id = 5}
+            };
+
+            //* Add categories here
+            _categories = new List<Category>()
+            {
+                // Categories for Reykofninn
+                new Category() {Name = "Lax", Id = 1},
+                new Category() {Name = "Silungur", Id = 2},
+                new Category() {Name = "Lambakjöt", Id = 3}
             };
         }
     }

--- a/Bakendi/ThjonustukerfiWebAPI/Controllers/InfoController.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Controllers/InfoController.cs
@@ -38,6 +38,15 @@ namespace ThjonustukerfiWebAPI.Controllers
             return Ok(_infoService.GetStates());
         }
 
-        //TODO get types
+        /// <summary>Gets all available categories</summary>
+        /// <returns>List of categories</returns>
+        /// <response code="200">Returns a list of available categories</response>
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [Route("categories")]
+        [HttpGet]
+        public IActionResult GetCategories()
+        {
+            return Ok(_infoService.GetCategories());
+        }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Controllers/InfoController.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Controllers/InfoController.cs
@@ -37,5 +37,7 @@ namespace ThjonustukerfiWebAPI.Controllers
         {
             return Ok(_infoService.GetStates());
         }
+
+        //TODO get types
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Mappings/MappingProfile.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Mappings/MappingProfile.cs
@@ -51,6 +51,10 @@ namespace ThjonustukerfiWebAPI.Mappings
             //* State Mappings
             // Automapper for State to StateDTO
             CreateMap<State, StateDTO>();
+
+            //* Category Mappings
+            // Automapper for Category to CategoryDTO
+            CreateMap<Category, CategoryDTO>();
         }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408102010_typeIsNowStoredAsIdInItem.Designer.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408102010_typeIsNowStoredAsIdInItem.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ThjonustukerfiWebAPI.Models;
@@ -9,9 +10,10 @@ using ThjonustukerfiWebAPI.Models;
 namespace ThjonustukerfiWebAPI.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20200408102010_typeIsNowStoredAsIdInItem")]
+    partial class typeIsNowStoredAsIdInItem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408102010_typeIsNowStoredAsIdInItem.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408102010_typeIsNowStoredAsIdInItem.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ThjonustukerfiWebAPI.Migrations
+{
+    public partial class typeIsNowStoredAsIdInItem : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Type",
+                table: "Item");
+
+            migrationBuilder.AddColumn<long>(
+                name: "TypeId",
+                table: "Item",
+                nullable: false,
+                defaultValue: 0L);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TypeId",
+                table: "Item");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Type",
+                table: "Item",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408102907_AddedTypeTable.Designer.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408102907_AddedTypeTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ThjonustukerfiWebAPI.Models;
@@ -9,33 +10,16 @@ using ThjonustukerfiWebAPI.Models;
 namespace ThjonustukerfiWebAPI.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20200408102907_AddedTypeTable")]
+    partial class AddedTypeTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
                 .HasAnnotation("ProductVersion", "3.1.1")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
-
-            modelBuilder.Entity("ThjonustukerfiWebAPI.Models.Entities.Category", b =>
-                {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
-                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
-
-                    b.Property<string>("JSON")
-                        .HasColumnType("text");
-
-                    b.Property<string>("Name")
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("Category");
-                });
 
             modelBuilder.Entity("ThjonustukerfiWebAPI.Models.Entities.Customer", b =>
                 {
@@ -86,9 +70,6 @@ namespace ThjonustukerfiWebAPI.Migrations
                     b.Property<string>("Barcode")
                         .HasColumnType("text");
 
-                    b.Property<long>("CategoryId")
-                        .HasColumnType("bigint");
-
                     b.Property<DateTime?>("DateCompleted")
                         .HasColumnType("timestamp without time zone");
 
@@ -105,6 +86,9 @@ namespace ThjonustukerfiWebAPI.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<long>("StateId")
+                        .HasColumnType("bigint");
+
+                    b.Property<long>("TypeId")
                         .HasColumnType("bigint");
 
                     b.HasKey("Id");
@@ -239,6 +223,24 @@ namespace ThjonustukerfiWebAPI.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("State");
+                });
+
+            modelBuilder.Entity("ThjonustukerfiWebAPI.Models.Entities.Type", b =>
+                {
+                    b.Property<long>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("bigint")
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+                    b.Property<string>("JSON")
+                        .HasColumnType("text");
+
+                    b.Property<string>("Name")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Type");
                 });
 #pragma warning restore 612, 618
         }

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408102907_AddedTypeTable.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408102907_AddedTypeTable.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace ThjonustukerfiWebAPI.Migrations
+{
+    public partial class AddedTypeTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Type",
+                columns: table => new
+                {
+                    Id = table.Column<long>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(nullable: true),
+                    JSON = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Type", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Type");
+        }
+    }
+}

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408111348_changedTypeToCategory.Designer.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408111348_changedTypeToCategory.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ThjonustukerfiWebAPI.Models;
@@ -9,9 +10,10 @@ using ThjonustukerfiWebAPI.Models;
 namespace ThjonustukerfiWebAPI.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20200408111348_changedTypeToCategory")]
+    partial class changedTypeToCategory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -86,9 +88,6 @@ namespace ThjonustukerfiWebAPI.Migrations
                     b.Property<string>("Barcode")
                         .HasColumnType("text");
 
-                    b.Property<long>("CategoryId")
-                        .HasColumnType("bigint");
-
                     b.Property<DateTime?>("DateCompleted")
                         .HasColumnType("timestamp without time zone");
 
@@ -105,6 +104,9 @@ namespace ThjonustukerfiWebAPI.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<long>("StateId")
+                        .HasColumnType("bigint");
+
+                    b.Property<long>("TypeId")
                         .HasColumnType("bigint");
 
                     b.HasKey("Id");

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408111348_changedTypeToCategory.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408111348_changedTypeToCategory.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace ThjonustukerfiWebAPI.Migrations
+{
+    public partial class changedTypeToCategory : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Type");
+
+            migrationBuilder.CreateTable(
+                name: "Category",
+                columns: table => new
+                {
+                    Id = table.Column<long>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(nullable: true),
+                    JSON = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Category", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Category");
+
+            migrationBuilder.CreateTable(
+                name: "Type",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    JSON = table.Column<string>(type: "text", nullable: true),
+                    Name = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Type", x => x.Id);
+                });
+        }
+    }
+}

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408112325_changedTypeIDtoCategoryIDinItemEntity.Designer.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408112325_changedTypeIDtoCategoryIDinItemEntity.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ThjonustukerfiWebAPI.Models;
@@ -9,9 +10,10 @@ using ThjonustukerfiWebAPI.Models;
 namespace ThjonustukerfiWebAPI.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20200408112325_changedTypeIDtoCategoryIDinItemEntity")]
+    partial class changedTypeIDtoCategoryIDinItemEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408112325_changedTypeIDtoCategoryIDinItemEntity.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200408112325_changedTypeIDtoCategoryIDinItemEntity.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ThjonustukerfiWebAPI.Migrations
+{
+    public partial class changedTypeIDtoCategoryIDinItemEntity : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TypeId",
+                table: "Item");
+
+            migrationBuilder.AddColumn<long>(
+                name: "CategoryId",
+                table: "Item",
+                nullable: false,
+                defaultValue: 0L);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CategoryId",
+                table: "Item");
+
+            migrationBuilder.AddColumn<long>(
+                name: "TypeId",
+                table: "Item",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+        }
+    }
+}

--- a/Bakendi/ThjonustukerfiWebAPI/Models/DTOs/CategoryDTO.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/DTOs/CategoryDTO.cs
@@ -1,0 +1,8 @@
+namespace ThjonustukerfiWebAPI.Models.DTOs
+{
+    public class CategoryDTO
+    {
+        public long Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/Bakendi/ThjonustukerfiWebAPI/Models/DTOs/ItemDTO.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/DTOs/ItemDTO.cs
@@ -4,7 +4,7 @@ namespace ThjonustukerfiWebAPI.Models.DTOs
     public class ItemDTO
     {
         public long Id { get; set; }
-        public string Type { get; set; }
+        public string Category { get; set; }
         public string Service { get; set; }
         public string State { get; set; }
         public string Barcode { get; set; }
@@ -21,7 +21,7 @@ namespace ThjonustukerfiWebAPI.Models.DTOs
                 return false;
             }
 
-            return i1.Id == i2.Id && i1.Type == i2.Type && i1.Service == i2.Service && i1.Barcode == i2.Barcode;
+            return i1.Id == i2.Id && i1.Category == i2.Category && i1.Service == i2.Service && i1.Barcode == i2.Barcode;
         }
 
         public static bool operator !=(ItemDTO i1, ItemDTO i2)

--- a/Bakendi/ThjonustukerfiWebAPI/Models/DTOs/ItemStateDTO.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/DTOs/ItemStateDTO.cs
@@ -7,7 +7,7 @@ namespace ThjonustukerfiWebAPI.Models.DTOs
     {
         public long Id { get; set; }
         public long OrderId { get; set; }
-        public string Type { get; set; }
+        public string Category { get; set; }
         public string State { get; set; }
         public DateTime DateModified { get; set; }
 
@@ -18,7 +18,7 @@ namespace ThjonustukerfiWebAPI.Models.DTOs
 
             if(object.ReferenceEquals(is1, null) || object.ReferenceEquals(is2, null)) { return false; }
 
-            return is1.Id == is2.Id && is1.OrderId == is2.OrderId && is1.Type == is2.Type && is1.State == is2.State && is1.DateModified == is2.DateModified;
+            return is1.Id == is2.Id && is1.OrderId == is2.OrderId && is1.Category == is2.Category && is1.State == is2.State && is1.DateModified == is2.DateModified;
         }
 
         public static bool operator !=(ItemStateDTO is1, ItemStateDTO is2)

--- a/Bakendi/ThjonustukerfiWebAPI/Models/DataContext.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/DataContext.cs
@@ -15,6 +15,7 @@ namespace ThjonustukerfiWebAPI.Models
         public virtual DbSet<Service> Service { get; set; }
         public virtual DbSet<State> State { get; set; }
         public virtual DbSet<ServiceState> ServiceState { get; set; }
+        public virtual DbSet<Category> Category { get; set; }
 
         //* Error logs
         public virtual DbSet<Log> ExceptionLog { get; set; }

--- a/Bakendi/ThjonustukerfiWebAPI/Models/Entities/Category.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/Entities/Category.cs
@@ -1,13 +1,13 @@
 namespace ThjonustukerfiWebAPI.Models.Entities
 {
-    public class Type
+    public class Category
     {
         public long Id { get; set; }
         public string Name { get; set; }
         public string JSON { get; set; }
 
         //*         Overrides         *//
-        public static bool operator ==(Type t1, Type t2)
+        public static bool operator ==(Category t1, Category t2)
         {
             if(object.ReferenceEquals(t1, t2)) { return true; }
             if(object.ReferenceEquals(t1, null) || object.ReferenceEquals(t2, null)) { return false; }
@@ -15,7 +15,7 @@ namespace ThjonustukerfiWebAPI.Models.Entities
             return t1.Id == t2.Id && t1.Name == t2.Name && t1.JSON == t2.JSON;
         }
 
-        public static bool operator !=(Type t1, Type t2)
+        public static bool operator !=(Category t1, Category t2)
         {
             return !(t1 == t2);
         }
@@ -25,14 +25,14 @@ namespace ThjonustukerfiWebAPI.Models.Entities
             return (int) Id;
         }
 
-        public bool Equals(Type other)
+        public bool Equals(Category other)
         {
             return this == other;
         }
 
         public override bool Equals(object obj)
         {
-            return Equals(obj as Type);
+            return Equals(obj as Category);
         }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Models/Entities/Item.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/Entities/Item.cs
@@ -7,7 +7,7 @@ namespace ThjonustukerfiWebAPI.Models.Entities
     public class Item
     {
         public long Id { get; set; }
-        public string Type { get; set; }
+        public long TypeId { get; set; }
         [ForeignKey("State")]
         public long StateId { get; set; }
         [ForeignKey("Service")]
@@ -31,7 +31,7 @@ namespace ThjonustukerfiWebAPI.Models.Entities
                 return false;
             }
 
-            return i1.Id == i2.Id && i1.Type == i2.Type && i1.StateId == i2.StateId &&
+            return i1.Id == i2.Id && i1.TypeId == i2.TypeId && i1.StateId == i2.StateId &&
                         i1.ServiceId == i2.ServiceId && i1.Barcode == i2.Barcode && i1.JSON == i2.JSON &&
                         i1.DateCreated == i2.DateCreated && i1.DateModified == i2.DateModified && i1.DateCompleted == i2.DateCompleted;
         }

--- a/Bakendi/ThjonustukerfiWebAPI/Models/Entities/Item.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/Entities/Item.cs
@@ -7,7 +7,7 @@ namespace ThjonustukerfiWebAPI.Models.Entities
     public class Item
     {
         public long Id { get; set; }
-        public long TypeId { get; set; }
+        public long CategoryId { get; set; }
         [ForeignKey("State")]
         public long StateId { get; set; }
         [ForeignKey("Service")]
@@ -31,7 +31,7 @@ namespace ThjonustukerfiWebAPI.Models.Entities
                 return false;
             }
 
-            return i1.Id == i2.Id && i1.TypeId == i2.TypeId && i1.StateId == i2.StateId &&
+            return i1.Id == i2.Id && i1.CategoryId == i2.CategoryId && i1.StateId == i2.StateId &&
                         i1.ServiceId == i2.ServiceId && i1.Barcode == i2.Barcode && i1.JSON == i2.JSON &&
                         i1.DateCreated == i2.DateCreated && i1.DateModified == i2.DateModified && i1.DateCompleted == i2.DateCompleted;
         }

--- a/Bakendi/ThjonustukerfiWebAPI/Models/Entities/Type.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/Entities/Type.cs
@@ -1,0 +1,38 @@
+namespace ThjonustukerfiWebAPI.Models.Entities
+{
+    public class Type
+    {
+        public long Id { get; set; }
+        public string Name { get; set; }
+        public string JSON { get; set; }
+
+        //*         Overrides         *//
+        public static bool operator ==(Type t1, Type t2)
+        {
+            if(object.ReferenceEquals(t1, t2)) { return true; }
+            if(object.ReferenceEquals(t1, null) || object.ReferenceEquals(t2, null)) { return false; }
+
+            return t1.Id == t2.Id && t1.Name == t2.Name && t1.JSON == t2.JSON;
+        }
+
+        public static bool operator !=(Type t1, Type t2)
+        {
+            return !(t1 == t2);
+        }
+
+        public override int GetHashCode()
+        {
+            return (int) Id;
+        }
+
+        public bool Equals(Type other)
+        {
+            return this == other;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Type);
+        }
+    }
+}

--- a/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/EditItemInput.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/EditItemInput.cs
@@ -3,7 +3,7 @@ namespace ThjonustukerfiWebAPI.Models.InputModels
     /// <summary>Input model to edit Item in the database.</summary>
     public class EditItemInput
     {
-        public string Type { get; set; }    //  type not right
+        public long? TypeId { get; set; }    //  type not right
         public long? StateId { get; set; }   //  manually need to change state
         public long? ServiceID { get; set; } //  service is not correct
         public long? OrderId { get; set; }   //  is not part of a correct order

--- a/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/EditItemInput.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/EditItemInput.cs
@@ -3,7 +3,7 @@ namespace ThjonustukerfiWebAPI.Models.InputModels
     /// <summary>Input model to edit Item in the database.</summary>
     public class EditItemInput
     {
-        public long? TypeId { get; set; }    //  type not right
+        public long? CategoryId { get; set; }    //  type not right
         public long? StateId { get; set; }   //  manually need to change state
         public long? ServiceID { get; set; } //  service is not correct
         public long? OrderId { get; set; }   //  is not part of a correct order

--- a/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemInputModel.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemInputModel.cs
@@ -3,7 +3,7 @@ namespace ThjonustukerfiWebAPI.Models.InputModels
     /// <summary>Input model to add new Item to the database.</summary>
     public class ItemInputModel
     {
-        public long TypeId { get; set; }
+        public long CategoryId { get; set; }
         public long ServiceId { get; set; }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemInputModel.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemInputModel.cs
@@ -3,7 +3,7 @@ namespace ThjonustukerfiWebAPI.Models.InputModels
     /// <summary>Input model to add new Item to the database.</summary>
     public class ItemInputModel
     {
-        public string Type { get; set; }
+        public long TypeId { get; set; }
         public long ServiceId { get; set; }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemInputModel.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemInputModel.cs
@@ -3,7 +3,7 @@ namespace ThjonustukerfiWebAPI.Models.InputModels
     /// <summary>Input model to add new Item to the database.</summary>
     public class ItemInputModel
     {
-        public long CategoryId { get; set; }
-        public long ServiceId { get; set; }
+        public long? CategoryId { get; set; }
+        public long? ServiceId { get; set; }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/InfoRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/InfoRepo.cs
@@ -25,5 +25,10 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
         {
             return _mapper.Map<IEnumerable<StateDTO>>(_dbContext.State.ToList());   // Get list and map to DTO list
         }
+
+        public IEnumerable<CategoryDTO> GetCategories()
+        {
+            return _mapper.Map<IEnumerable<CategoryDTO>>(_dbContext.Category.ToList()); // Get list and map to DTO list
+        }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
@@ -28,9 +28,10 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             // Map the DTO
             var stateDTO = _mapper.Map<ItemStateDTO>(entity);
 
-            // Get the connections for the DTO, order id it belongs to and in what state it is
-            stateDTO.OrderId = _dbContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == entity.Id).OrderId;
-            stateDTO.State = _dbContext.State.FirstOrDefault(s => s.Id == entity.StateId).Name;
+            // Get the connections for the DTO
+            stateDTO.OrderId = _dbContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == entity.Id).OrderId;   // get order ID
+            stateDTO.State = _dbContext.State.FirstOrDefault(s => s.Id == entity.StateId).Name;                         // get state name
+            stateDTO.Category = _dbContext.Category.FirstOrDefault(c => c.Id == entity.CategoryId).Name;                // get category name
 
             return stateDTO;
         }
@@ -82,8 +83,8 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             if(editService) { entity.ServiceId = (long)input.ServiceID; }
             if(editOrder)
             {
-                var connection = _dbContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == itemId);
-                connection.OrderId = (long)input.OrderId;
+                var connection = _dbContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == itemId);    // get the item order connection
+                connection.OrderId = (long)input.OrderId;   // update the connection to the order
             }
 
             // If no changes are made, send a bad request response
@@ -95,7 +96,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
 
                 _dbContext.Order.FirstOrDefault(o =>
                     o.Id == _dbContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == entity.Id).OrderId)  // find order connected to this item
-                        .DateModified = DateTime.Now;
+                        .DateModified = DateTime.Now;   // Update the date modified attribute in the order connected to this item
             }
 
             _dbContext.SaveChanges();

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
@@ -71,8 +71,9 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 if(_dbContext.Order.FirstOrDefault(o => o.Id == input.OrderId) == null) { throw new NotFoundException($"Order with ID {input.OrderId} was not found."); }
                 editOrder = true;
             }
+            //! ADD CHECK FOR TYPE AFTER ADDING THE TABLE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-            if(input.Type != null) { entity.Type = input.Type; }  // just edit if not empty
+            if(input.TypeId != null) { entity.TypeId = (long)input.TypeId; }
             if(editState) { entity.StateId = (long)input.StateId; }
             if(editService) { entity.ServiceId = (long)input.ServiceID; }
             if(editOrder)
@@ -82,7 +83,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             }
 
             // If no changes are made, send a bad request response
-            if(input.Type == null && !editState && !editService && !editOrder) {throw new BadRequestException($"The input had no valid values. No changes made."); }
+            if(input.TypeId == null && !editState && !editService && !editOrder) {throw new BadRequestException($"The input had no valid values. No changes made."); }
             else 
             {
                 // item and the order connected to it modified on this date

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
@@ -50,8 +50,8 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             var entity = _dbContext.Item.FirstOrDefault(i => i.Id == itemId);
             if(entity == null) { throw new NotFoundException($"Item with ID {itemId} was not found."); }
 
-            bool editState, editService, editOrder;
-            editState = editService = editOrder = false;
+            bool editState, editService, editOrder, editCategory;
+            editState = editService = editOrder = editCategory = false;
 
             // finish all checks before editing anything, unfilled inputs will not be edited
             if(input.StateId != null)
@@ -71,9 +71,13 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 if(_dbContext.Order.FirstOrDefault(o => o.Id == input.OrderId) == null) { throw new NotFoundException($"Order with ID {input.OrderId} was not found."); }
                 editOrder = true;
             }
-            //! ADD CHECK FOR TYPE AFTER ADDING THE TABLE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            if(input.CategoryId != null)
+            {
+                if(_dbContext.Category.FirstOrDefault(t => t.Id == input.CategoryId) == null) { throw new NotFoundException($"Category with ID {input.CategoryId} was not found."); }
+                editCategory = true;
+            }
 
-            if(input.TypeId != null) { entity.TypeId = (long)input.TypeId; }
+            if(editCategory) { entity.CategoryId = (long)input.CategoryId; }
             if(editState) { entity.StateId = (long)input.StateId; }
             if(editService) { entity.ServiceId = (long)input.ServiceID; }
             if(editOrder)
@@ -83,7 +87,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             }
 
             // If no changes are made, send a bad request response
-            if(input.TypeId == null && !editState && !editService && !editOrder) {throw new BadRequestException($"The input had no valid values. No changes made."); }
+            if(!editCategory && !editState && !editService && !editOrder) {throw new BadRequestException($"The input had no valid values. No changes made."); }
             else 
             {
                 // item and the order connected to it modified on this date

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
@@ -90,6 +90,9 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             var entity = _dbContext.Order.FirstOrDefault(o => o.Id == id);
             if(entity == null) { throw new NotFoundException($"Order with id {id} was not found."); }
 
+            // Customer in input not valid
+            if(_dbContext.Customer.FirstOrDefault(c => c.Id == order.CustomerId) == null) { throw new NotFoundException($"Customer with ID {order.CustomerId} was not found."); }
+
             // Make sure that the items that are being added have the correct service and category
             foreach(ItemInputModel item in order.Items)
             {

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
@@ -113,8 +113,8 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             {
                 for(var i = 0; i < items.Count; i++)
                 {
-                    items[i].CategoryId = order.Items[i].CategoryId;
-                    items[i].ServiceId = order.Items[i].ServiceId;
+                    items[i].CategoryId = (long)order.Items[i].CategoryId;
+                    items[i].ServiceId = (long)order.Items[i].ServiceId;
                     items[i].DateModified = DateTime.Now;
                 }
             }
@@ -128,8 +128,8 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 var i = 0;
                 for( ; i < items.Count; i++)
                 {
-                    items[i].CategoryId = order.Items[i].CategoryId;
-                    items[i].ServiceId = order.Items[i].ServiceId;
+                    items[i].CategoryId = (long)order.Items[i].CategoryId;
+                    items[i].ServiceId = (long)order.Items[i].ServiceId;
                     items[i].DateModified = DateTime.Now;
                 }
 
@@ -149,8 +149,8 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 var i = 0;
                 for( ; i < order.Items.Count; i++)
                 {
-                    items[i].CategoryId = order.Items[i].CategoryId;
-                    items[i].ServiceId = order.Items[i].ServiceId;
+                    items[i].CategoryId = (long)order.Items[i].CategoryId;
+                    items[i].ServiceId = (long)order.Items[i].ServiceId;
                     items[i].DateModified = DateTime.Now;
                 }
 

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
@@ -104,7 +104,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             {
                 for(var i = 0; i < items.Count; i++)
                 {
-                    items[i].Type = order.Items[i].Type;
+                    items[i].TypeId = order.Items[i].TypeId;
                     items[i].ServiceId = order.Items[i].ServiceId;
                     items[i].DateModified = DateTime.Now;
                 }
@@ -119,7 +119,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 var i = 0;
                 for( ; i < items.Count; i++)
                 {
-                    items[i].Type = order.Items[i].Type;
+                    items[i].TypeId = order.Items[i].TypeId;
                     items[i].ServiceId = order.Items[i].ServiceId;
                     items[i].DateModified = DateTime.Now;
                 }
@@ -140,7 +140,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 var i = 0;
                 for( ; i < order.Items.Count; i++)
                 {
-                    items[i].Type = order.Items[i].Type;
+                    items[i].TypeId = order.Items[i].TypeId;
                     items[i].ServiceId = order.Items[i].ServiceId;
                     items[i].DateModified = DateTime.Now;
                 }

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
@@ -52,7 +52,8 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             // TODO replace for actual barcode in both order and Item
             foreach(ItemInputModel item in order.Items)
             {
-                if(_dbContext.Service.FirstOrDefault(s => s.Id == item.ServiceId) == null) { throw new NotFoundException($"Service with id {item.ServiceId} was not found."); }
+                if(_dbContext.Service.FirstOrDefault(s => s.Id == item.ServiceId) == null) { throw new NotFoundException($"Service with ID {item.ServiceId} was not found."); }
+                if(_dbContext.Category.FirstOrDefault(c => c.Id == item.CategoryId) == null) { throw new NotFoundException($"Category with ID {item.CategoryId} was not found."); }
             }
             var orderToAdd = _mapper.Map<Order>(order);
             var barcodeEntry = _dbContext.Order.OrderByDescending(o => o.Barcode).FirstOrDefault();
@@ -88,6 +89,13 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             var entity = _dbContext.Order.FirstOrDefault(o => o.Id == id);
             if(entity == null) { throw new NotFoundException($"Order with id {id} was not found."); }
 
+            // Make sure that the items that are being added have the correct service and category
+            foreach(ItemInputModel item in order.Items)
+            {
+                if(_dbContext.Service.FirstOrDefault(s => s.Id == item.ServiceId) == null) { throw new NotFoundException($"Service with ID {item.ServiceId} was not found."); }
+                if(_dbContext.Category.FirstOrDefault(c => c.Id == item.CategoryId) == null) { throw new NotFoundException($"Category with ID {item.CategoryId} was not found."); }
+            }
+
             // update the customer ID
             entity.CustomerId = order.CustomerId;
 
@@ -104,7 +112,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             {
                 for(var i = 0; i < items.Count; i++)
                 {
-                    items[i].TypeId = order.Items[i].TypeId;
+                    items[i].CategoryId = order.Items[i].CategoryId;
                     items[i].ServiceId = order.Items[i].ServiceId;
                     items[i].DateModified = DateTime.Now;
                 }
@@ -119,7 +127,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 var i = 0;
                 for( ; i < items.Count; i++)
                 {
-                    items[i].TypeId = order.Items[i].TypeId;
+                    items[i].CategoryId = order.Items[i].CategoryId;
                     items[i].ServiceId = order.Items[i].ServiceId;
                     items[i].DateModified = DateTime.Now;
                 }
@@ -140,7 +148,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 var i = 0;
                 for( ; i < order.Items.Count; i++)
                 {
-                    items[i].TypeId = order.Items[i].TypeId;
+                    items[i].CategoryId = order.Items[i].CategoryId;
                     items[i].ServiceId = order.Items[i].ServiceId;
                     items[i].DateModified = DateTime.Now;
                 }

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
@@ -40,7 +40,8 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 var itemEntity = _dbContext.Item.FirstOrDefault(i => i.Id == item.ItemId);                  // get item entity
                 var add = _mapper.Map<ItemDTO>(itemEntity);                                                 // map to DTO
                 add.Service = _dbContext.Service.FirstOrDefault(s => s.Id == itemEntity.ServiceId).Name;    // Find service name
-                add.State = _dbContext.State.FirstOrDefault(s => s.Id == itemEntity.StateId).Name;
+                add.State = _dbContext.State.FirstOrDefault(s => s.Id == itemEntity.StateId).Name;          // Find state name
+                add.Category = _dbContext.Category.FirstOrDefault(c => c.Id == itemEntity.CategoryId).Name; // Find category name 
                 dto.Items.Add(add);     // add item DTO to orderDTO item list
             }
 
@@ -337,6 +338,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                     var add = _mapper.Map<ItemDTO>(itemEntity);                                                 // map to DTO
                     add.Service = _dbContext.Service.FirstOrDefault(s => s.Id == itemEntity.ServiceId).Name;    // Find Service name
                     add.State = _dbContext.State.FirstOrDefault(s => s.Id == itemEntity.StateId).Name;          // Find state name
+                    add.Category = _dbContext.Category.FirstOrDefault(c => c.Id == itemEntity.CategoryId).Name; // Find category name
                     dto.Items.Add(add);     // Add the itemDTO to the orderDTO
                 }
 

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Interfaces/IInfoRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Interfaces/IInfoRepo.cs
@@ -12,5 +12,9 @@ namespace ThjonustukerfiWebAPI.Repositories.Interfaces
         /// <summary>Gets all states available for the product/service</summary>
         /// <returns>A list of all available services.</returns>
         IEnumerable<StateDTO> GetStates();
+
+        /// <summary>Gets all categories of items</summary>
+        /// <returns>A list of all categories</returns>
+        IEnumerable<CategoryDTO> GetCategories();
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Services/Implementations/InfoService.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Services/Implementations/InfoService.cs
@@ -14,5 +14,7 @@ namespace ThjonustukerfiWebAPI.Services.Implementations
         }
         public IEnumerable GetServices() => _infoRepo.GetServices();
         public IEnumerable GetStates() => _infoRepo.GetStates();
+
+        public IEnumerable GetCategories() => _infoRepo.GetCategories();
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Services/Interfaces/IInfoService.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Services/Interfaces/IInfoService.cs
@@ -11,5 +11,9 @@ namespace ThjonustukerfiWebAPI.Services.Interfaces
         /// <summary>Gets all states available for the product/service</summary>
         /// <returns>A list of all states.</returns>
         IEnumerable GetStates();
+
+        /// <summary>Gets all categories of items</summary>
+        /// <returns>A list of all categories</returns>
+        IEnumerable GetCategories();
     }
 }


### PR DESCRIPTION
Please read this:
New table called category.
Removed Type from everywhere, now it's category.
All relations between entities, input, and DTO are fixed with the new table.
Starting up the webhost app also creates Category tables now, also added more services and service states.
All tests work as well with the change, also added some tests as well as extending some for the new table and entity changes.
Info controller now has an endpoint that gets all categories.

Since tables where changed you might need to run dotnet ef database update.
dotnet restore may also work this time, but not sure.
If you get any errors, please clear your orders and items tables (do not drop them), then do dotnet ef database update
Let me know if you land in any trouble guys! 👍 