### PR TITLE
Change item state

### DIFF
--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemControllerTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemControllerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -149,6 +150,42 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             //* Assert
             Assert.IsNotNull(response);
             Assert.AreEqual(204, response.StatusCode);
+        }
+
+        [TestMethod]
+        public void ChangeItemStateById_should_return_an_OKresult()
+        {
+            //* Arrange
+            // Mock Service
+            _itemServiceMock.Setup(method => method.ChangeItemStateById(It.IsAny<List<ItemStateChangeInputModel>>())).Verifiable();
+
+            // Create controller
+            _itemController = new ItemController(_itemServiceMock.Object);
+
+            //* Act
+            var response = _itemController.ChangeItemStateById(new List<ItemStateChangeInputModel>()) as OkResult;
+
+            //* Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(200, response.StatusCode);
+        }
+
+        [TestMethod]
+        public void ChangeItemStateBarcode_should_return_an_OKresult()
+        {
+            //* Arrange
+            // Mock Service
+            _itemServiceMock.Setup(method => method.ChangeItemStateBarcode(It.IsAny<List<ItemStateChangeBarcodeInputModel>>())).Verifiable();
+
+            // Create controller
+            _itemController = new ItemController(_itemServiceMock.Object);
+
+            //* Act
+            var response = _itemController.ChangeItemStateBarcode(new List<ItemStateChangeBarcodeInputModel>()) as OkResult;
+
+            //* Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(200, response.StatusCode);
         }
     }
 }

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemControllerTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemControllerTests.cs
@@ -156,14 +156,15 @@ namespace ThjonustukerfiTests.Tests.ItemTests
         public void ChangeItemStateById_should_return_an_OKresult()
         {
             //* Arrange
+            var emptyList = new List<ItemStateChangeInputModel>();
             // Mock Service
-            _itemServiceMock.Setup(method => method.ChangeItemStateById(It.IsAny<List<ItemStateChangeInputModel>>())).Verifiable();
+            _itemServiceMock.Setup(method => method.ChangeItemStateById(It.IsAny<List<ItemStateChangeInputModel>>())).Returns(emptyList).Verifiable();
 
             // Create controller
             _itemController = new ItemController(_itemServiceMock.Object);
 
             //* Act
-            var response = _itemController.ChangeItemStateById(new List<ItemStateChangeInputModel>()) as OkResult;
+            var response = _itemController.ChangeItemStateById(emptyList) as OkResult;
 
             //* Assert
             Assert.IsNotNull(response);
@@ -174,14 +175,15 @@ namespace ThjonustukerfiTests.Tests.ItemTests
         public void ChangeItemStateBarcode_should_return_an_OKresult()
         {
             //* Arrange
+            var emptyList = new List<ItemStateChangeBarcodeInputModel>();
             // Mock Service
-            _itemServiceMock.Setup(method => method.ChangeItemStateBarcode(It.IsAny<List<ItemStateChangeBarcodeInputModel>>())).Verifiable();
+            _itemServiceMock.Setup(method => method.ChangeItemStateBarcode(It.IsAny<List<ItemStateChangeBarcodeInputModel>>())).Returns(emptyList).Verifiable();
 
             // Create controller
             _itemController = new ItemController(_itemServiceMock.Object);
 
             //* Act
-            var response = _itemController.ChangeItemStateBarcode(new List<ItemStateChangeBarcodeInputModel>()) as OkResult;
+            var response = _itemController.ChangeItemStateBarcode(emptyList) as OkResult;
 
             //* Assert
             Assert.IsNotNull(response);

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemControllerTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemControllerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -172,6 +173,38 @@ namespace ThjonustukerfiTests.Tests.ItemTests
         }
 
         [TestMethod]
+        public void ChangeItemStateById_should_return_AcceptedResult_and_list_of_invalid_inputs()
+        {
+            //* Arrange
+            var input = new List<ItemStateChangeInputModel>()
+            {
+                new ItemStateChangeInputModel { ItemId = -1, StateChangeTo = -1 },
+                new ItemStateChangeInputModel { ItemId = 1, StateChangeTo = 2 }
+            };
+
+            var invalidInputs = new List<ItemStateChangeInputModel>()
+            {
+                new ItemStateChangeInputModel { ItemId = -1, StateChangeTo = -1 }
+            };
+
+            // Mock service
+            _itemServiceMock.Setup(method => method.ChangeItemStateById(input)).Returns(invalidInputs).Verifiable();
+
+            // Create controller
+            _itemController = new ItemController(_itemServiceMock.Object);
+
+            //* Act
+            var response = _itemController.ChangeItemStateById(input) as AcceptedResult;
+
+            //* Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(StatusCodes.Status202Accepted, response.StatusCode);
+            
+            var retVal = response.Value as List<ItemStateChangeInputModel>;
+            Assert.AreEqual(invalidInputs.Count, retVal.Count);
+        }
+
+        [TestMethod]
         public void ChangeItemStateBarcode_should_return_an_OKresult()
         {
             //* Arrange
@@ -188,6 +221,38 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             //* Assert
             Assert.IsNotNull(response);
             Assert.AreEqual(200, response.StatusCode);
+        }
+
+        [TestMethod]
+        public void ChangeItemStateByBarcode_should_return_AcceptedResult_and_list_of_invalid_inputs()
+        {
+            //* Arrange
+            var input = new List<ItemStateChangeBarcodeInputModel>()
+            {
+                new ItemStateChangeBarcodeInputModel { Barcode = "-1", StateChangeTo = -1 },
+                new ItemStateChangeBarcodeInputModel { Barcode = "983764892374", StateChangeTo = 2 }
+            };
+            
+            var invalidInputs = new List<ItemStateChangeBarcodeInputModel>()
+            {
+                new ItemStateChangeBarcodeInputModel { Barcode = "-1", StateChangeTo = -1 }
+            };
+
+            // Mock service
+            _itemServiceMock.Setup(method => method.ChangeItemStateBarcode(input)).Returns(invalidInputs).Verifiable();
+
+            // Create controller
+            _itemController = new ItemController(_itemServiceMock.Object);
+
+            //* Act
+            var response = _itemController.ChangeItemStateBarcode(input) as AcceptedResult;
+
+            //* Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(StatusCodes.Status202Accepted, response.StatusCode);
+            
+            var retVal = response.Value as List<ItemStateChangeBarcodeInputModel>;
+            Assert.AreEqual(invalidInputs.Count, retVal.Count);
         }
     }
 }

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemRepoTests.cs
@@ -469,10 +469,8 @@ namespace ThjonustukerfiTests.Tests.ItemTests
                 IItemRepo itemRepo = new ItemRepo(mockContext, _mapper);
 
                 //* Act and Assert
-                // Invalid itemId
-                Assert.ThrowsException<NotFoundException>(() => itemRepo.ChangeItemStateById(input1));
-                // Invalid StateID
-                Assert.ThrowsException<NotFoundException>(() => itemRepo.ChangeItemStateById(input2));
+                Assert.ThrowsException<NotFoundException>(() => itemRepo.ChangeItemStateById(input1));  // Invalid itemId
+                Assert.ThrowsException<NotFoundException>(() => itemRepo.ChangeItemStateById(input2));  // Invalid StateID
             }
         }
 

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemRepoTests.cs
@@ -263,6 +263,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
                 itemDTO.OrderId = mockContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == itemEntity.Id).OrderId;
                 itemDTO.State = mockContext.State.FirstOrDefault(s => s.Id == itemEntity.StateId).Name;
                 itemDTO.Category = mockContext.Category.FirstOrDefault(c => c.Id == itemEntity.CategoryId).Name;
+                itemDTO.Service = mockContext.Service.FirstOrDefault(s => s.Id == itemEntity.ServiceId).Name;
 
                 //* Act
                 var retVal = itemRepo.GetItemById(itemID);

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemRepoTests.cs
@@ -451,6 +451,73 @@ namespace ThjonustukerfiTests.Tests.ItemTests
         }
 
         [TestMethod]
+        public void ChangeItemStateById_should_return_an_invalid_list()
+        {
+            //* Arrange
+            long invalidId = -1;
+            long invalidState = -1;
+            long validId = 2;
+            long validState = 5;
+
+            // The input with valid and invalid variables
+            var input = new List<ItemStateChangeInputModel>()
+            {
+                new ItemStateChangeInputModel { ItemId = invalidId, StateChangeTo = validState },
+                new ItemStateChangeInputModel { ItemId = validId, StateChangeTo = invalidState },
+                new ItemStateChangeInputModel { ItemId = validId, StateChangeTo = validState }
+            };
+
+            // Expected return from the function
+            var expectedReturn = new List<ItemStateChangeInputModel>()
+            {
+                new ItemStateChangeInputModel { ItemId = invalidId, StateChangeTo = validState },
+                new ItemStateChangeInputModel { ItemId = validId, StateChangeTo = invalidState }
+            };
+
+            using(var mockContext = new DataContext(_options))
+            {
+                var itemRepo = new ItemRepo(mockContext, _mapper);
+
+                //* Act
+                var returnedValue = itemRepo.ChangeItemStateById(input);
+
+                //* Assert
+                Assert.IsNotNull(returnedValue);
+                Assert.AreEqual(expectedReturn.Count, returnedValue.Count);
+                foreach (var inp in returnedValue)
+                {
+                    Assert.IsTrue(expectedReturn.Contains(inp));
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ChangeItemStateById_should_return_an_empty_list()
+        {
+            //* Arrange
+            long validId = 2;
+            long validState = 5;
+
+            // The input with valid and invalid variables
+            var input = new List<ItemStateChangeInputModel>()
+            {
+                new ItemStateChangeInputModel { ItemId = validId, StateChangeTo = validState }
+            };
+
+            using(var mockContext = new DataContext(_options))
+            {
+                var itemRepo = new ItemRepo(mockContext, _mapper);
+
+                //* Act
+                var returnedValue = itemRepo.ChangeItemStateById(input);
+
+                //* Assert
+                Assert.IsNotNull(returnedValue);
+                Assert.AreEqual(0, returnedValue.Count);
+            }
+        }
+
+        [TestMethod]
         public void ChangeItemStateById_should_throw_correct_exceptions()
         {
             //* Arrange
@@ -469,6 +536,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
                 IItemRepo itemRepo = new ItemRepo(mockContext, _mapper);
 
                 //* Act and Assert
+                // The exceptions are thrown because there is no valid inputs
                 Assert.ThrowsException<NotFoundException>(() => itemRepo.ChangeItemStateById(input1));  // Invalid itemId
                 Assert.ThrowsException<NotFoundException>(() => itemRepo.ChangeItemStateById(input2));  // Invalid StateID
             }

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemServiceTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemServiceTests.cs
@@ -1,6 +1,8 @@
 using System;
+using AutoMapper;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using ThjonustukerfiWebAPI.Mappings;
 using ThjonustukerfiWebAPI.Models.DTOs;
 using ThjonustukerfiWebAPI.Repositories.Interfaces;
 using ThjonustukerfiWebAPI.Services.Implementations;
@@ -13,11 +15,17 @@ namespace ThjonustukerfiTests.Tests.ItemTests
     {
         private IItemService _itemService;
         private Mock<IItemRepo> _itemRepoMock;
+        private Mapper _mapper;
 
         [TestInitialize]
         public void Initialize()
         {
             _itemRepoMock = new Mock<IItemRepo>();
+
+            // Setting up automapper
+            var myProfile = new MappingProfile();   // Create a new profile like the one we implemented
+            var myConfig = new MapperConfiguration(cfg => cfg.AddProfile(myProfile));   // Setup a configuration with our profile
+            _mapper = new Mapper(myConfig); // Create a new mapper with our profile
         }
 
         [TestMethod]
@@ -38,7 +46,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             _itemRepoMock.Setup(method => method.GetItemById(itemID)).Returns(retDTO);
 
             // Create controller
-            _itemService = new ItemService(_itemRepoMock.Object);
+            _itemService = new ItemService(_itemRepoMock.Object, _mapper);
 
             //* Act
             var response = _itemService.SearchItem("someString");
@@ -66,7 +74,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             _itemRepoMock.Setup(method => method.GetItemById(itemID)).Returns(itemstate);
 
             // Create service
-            _itemService = new ItemService(_itemRepoMock.Object);
+            _itemService = new ItemService(_itemRepoMock.Object, _mapper);
 
             //* Act
             var retVal = _itemService.GetItemById(itemID);

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemServiceTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemServiceTests.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Generic;
 using AutoMapper;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using ThjonustukerfiWebAPI.Mappings;
 using ThjonustukerfiWebAPI.Models.DTOs;
+using ThjonustukerfiWebAPI.Models.Exceptions;
+using ThjonustukerfiWebAPI.Models.InputModels;
 using ThjonustukerfiWebAPI.Repositories.Interfaces;
 using ThjonustukerfiWebAPI.Services.Implementations;
 using ThjonustukerfiWebAPI.Services.Interfaces;
@@ -82,6 +85,96 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             //* Assert
             Assert.IsNotNull(retVal);
             Assert.IsInstanceOfType(retVal, typeof(ItemStateDTO));
+        }
+
+        [TestMethod]
+        public void ChangeItemStateBarcode_should_return_invalid_list()
+        {
+            string validBarcode = "983764892374";
+            string invalidbarcode = "-1";
+            //* Arrange
+            var input = new List<ItemStateChangeBarcodeInputModel>()
+            {
+                new ItemStateChangeBarcodeInputModel { Barcode = invalidbarcode, StateChangeTo = 1 },
+                new ItemStateChangeBarcodeInputModel { Barcode = validBarcode, StateChangeTo = 2 }
+            };
+            
+            var invalidInputs = new List<ItemStateChangeBarcodeInputModel>()
+            {
+                new ItemStateChangeBarcodeInputModel { Barcode = invalidbarcode, StateChangeTo = 1 }
+            };
+
+            // Mock Repo
+            _itemRepoMock.Setup(method => method.SearchItem(invalidbarcode)).Throws(new NotFoundException("Some message"));
+            _itemRepoMock.Setup(method => method.SearchItem(validBarcode)).Returns(1);
+            _itemRepoMock.Setup(method => method.ChangeItemStateById(It.IsAny<List<ItemStateChangeInputModel>>()))
+                .Returns(new List<ItemStateChangeInputModel>());
+
+            // create service
+            _itemService = new ItemService(_itemRepoMock.Object, _mapper);
+
+            //* Act
+            var retVal = _itemService.ChangeItemStateBarcode(input);
+
+            //* Assert
+            Assert.IsNotNull(retVal);
+            Assert.AreEqual(invalidInputs.Count, retVal.Count);
+            Assert.AreEqual(invalidInputs[0], retVal[0]);
+        }
+
+        [TestMethod]
+        public void ChangeItemStateBarcode_should_return_empty_list()
+        {
+            string validBarcode = "983764892374";
+            string validBarcode2 = "983764892375";
+            //* Arrange
+            var input = new List<ItemStateChangeBarcodeInputModel>()
+            {
+                new ItemStateChangeBarcodeInputModel { Barcode = validBarcode, StateChangeTo = 1 },
+                new ItemStateChangeBarcodeInputModel { Barcode = validBarcode2, StateChangeTo = 2 }
+            };
+
+            // Mock Repo
+            _itemRepoMock.Setup(method => method.SearchItem(validBarcode)).Returns(1);
+            _itemRepoMock.Setup(method => method.ChangeItemStateById(It.IsAny<List<ItemStateChangeInputModel>>()))
+                .Returns(new List<ItemStateChangeInputModel>());
+
+            // create service
+            _itemService = new ItemService(_itemRepoMock.Object, _mapper);
+
+            //* Act
+            var retVal = _itemService.ChangeItemStateBarcode(input);
+
+            //* Assert
+            Assert.IsNotNull(retVal);
+            Assert.AreEqual(0, retVal.Count);
+        }
+
+        [TestMethod]
+        public void ChangeItemStateById_should_return_empty_list()
+        {
+            long validId = 1;
+            long validId2 = 2;
+            //* Arrange
+            var input = new List<ItemStateChangeInputModel>()
+            {
+                new ItemStateChangeInputModel { ItemId = validId, StateChangeTo = 1 },
+                new ItemStateChangeInputModel { ItemId = validId2, StateChangeTo = 2 }
+            };
+
+            // Mock Repo
+            _itemRepoMock.Setup(method => method.ChangeItemStateById(It.IsAny<List<ItemStateChangeInputModel>>()))
+                .Returns(new List<ItemStateChangeInputModel>());
+
+            // create service
+            _itemService = new ItemService(_itemRepoMock.Object, _mapper);
+
+            //* Act
+            var retVal = _itemService.ChangeItemStateById(input);
+
+            //* Assert
+            Assert.IsNotNull(retVal);
+            Assert.AreEqual(0, retVal.Count);
         }
     }
 }

--- a/Bakendi/ThjonustukerfiTests/Tests/Order/OrderRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Order/OrderRepoTests.cs
@@ -815,6 +815,13 @@ namespace ThjonustukerfiTests.Tests
                 }
             };
 
+            // Adding timestamp
+            List<ItemTimestamp> mockTimestamps = new List<ItemTimestamp>();
+            foreach (var item in mockItems)
+            {
+                mockTimestamps.Add(_mapper.Map<ItemTimestamp>(item));
+            }
+
             // Adding service
             var mockServices = new List<Service>()
             {
@@ -874,6 +881,7 @@ namespace ThjonustukerfiTests.Tests
             mockContext.Customer.AddRange(customers);
             mockContext.ItemOrderConnection.AddRange(mockIOConnect);
             mockContext.Item.AddRange(mockItems);
+            mockContext.ItemTimestamp.AddRange(mockTimestamps);
             mockContext.Service.AddRange(mockServices);
             mockContext.State.AddRange(states);
             mockContext.Category.AddRange(categories);

--- a/Bakendi/ThjonustukerfiTests/Tests/Order/OrderRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/Order/OrderRepoTests.cs
@@ -81,6 +81,7 @@ namespace ThjonustukerfiTests.Tests
                 Assert.IsTrue(mockContext.Item.Any());
                 Assert.IsTrue(mockContext.Service.Any());
                 Assert.IsTrue(mockContext.State.Any());
+                Assert.IsTrue(mockContext.ItemTimestamp.Any());
             }
         }
 
@@ -182,12 +183,15 @@ namespace ThjonustukerfiTests.Tests
                 var resultOrderDTO = mockContext.Order.OrderByDescending(o => o.Id).FirstOrDefault();
                 // Get a list of all itemOrderConnections created
                 var itemOrderConnectionDTOList = mockContext.ItemOrderConnection.Where(i => i.OrderId == result).ToList();
-                // Get all items added to the database using ItemOrderConnection
+                // Get all items and timestamps added to the database using ItemOrderConnection
                 var itemListDTO = new List<Item>();
+                var itemTimestamps = new List<ItemTimestamp>();
                 foreach (var item in itemOrderConnectionDTOList)
                 {
                     var add = _mapper.Map<Item>(mockContext.Item.Find(item.ItemId));
                     itemListDTO.Add(add);
+
+                    itemTimestamps.AddRange(mockContext.ItemTimestamp.Where(ts => ts.ItemId == item.ItemId).ToList());
                 }
 
                 //* Assert
@@ -211,6 +215,9 @@ namespace ThjonustukerfiTests.Tests
                 Assert.AreEqual(itemOrderConnectionDTOList[1].OrderId, resultOrderDTO.Id);
                 Assert.AreEqual(itemOrderConnectionDTOList[1].ItemId, itemListDTO[1].Id);
 
+                // Assert Timestamp
+                // since no updates have been made since creating, there should be the same amout of timestamps as their are items in the order
+                Assert.AreEqual(itemListDTO.Count, itemTimestamps.Count);
             };
         }
 
@@ -585,6 +592,7 @@ namespace ThjonustukerfiTests.Tests
                 };
                 var itemOrderConnection = mockContext.ItemOrderConnection.Where(ioc => ioc.OrderId == orderID).ToList();
                 var oldItemsStates = new List<Item>();
+                var oldItemsTimestamps = new List<ItemTimestamp>();
                 foreach (var item in itemOrderConnection)
                 {
                     var entity = mockContext.Item.FirstOrDefault(i => i.Id == item.ItemId);
@@ -600,6 +608,9 @@ namespace ThjonustukerfiTests.Tests
                         DateModified = entity.DateModified,
                         DateCompleted = entity.DateCompleted
                     });
+
+                    // adding timestamps
+                    oldItemsTimestamps.AddRange(mockContext.ItemTimestamp.Where(ts => ts.ItemId == entity.Id).ToList());
                 }
 
                 //* Act
@@ -607,10 +618,13 @@ namespace ThjonustukerfiTests.Tests
 
                 orderEntity = mockContext.Order.FirstOrDefault(o => o.Id == orderID);
                 var newItemStates = new List<Item>();
+                var newItemsTimestamps = new List<ItemTimestamp>();
                 foreach (var item in itemOrderConnection)
                 {
                     newItemStates.Add(mockContext.Item.FirstOrDefault(i => i.Id == item.ItemId));
+                    newItemsTimestamps.AddRange(mockContext.ItemTimestamp.Where(ts => ts.ItemId == item.ItemId).ToList());
                 }
+
                 //* Assert
                 // Order
                 Assert.IsNotNull(orderEntity);
@@ -627,6 +641,9 @@ namespace ThjonustukerfiTests.Tests
                     Assert.AreNotEqual(oldItemsStates[i], newItemStates[i]);
                     Assert.AreEqual(5, newItemStates[i].StateId);   //TODO more general that 5, same as before
                 }
+
+                // check the timestamps, each item should have 1 new timestamp (timestamp when completed)
+                Assert.AreEqual(oldItemsTimestamps.Count + newItemStates.Count, newItemsTimestamps.Count);
             }
         }
 
@@ -692,20 +709,27 @@ namespace ThjonustukerfiTests.Tests
             {
                 var orderRepo = new OrderRepo(mockContext, _mapper);
 
-                var orderTableSize = mockContext.Order.Count();
-                var itemTableSize = mockContext.Item.Count();
-                var itemOrderConnectionTableSize = mockContext.ItemOrderConnection.Count();
+                var orderTableSize = mockContext.Order.Count(); // size of ordertable before delete
+                var itemTableSize = mockContext.Item.Count();   // item table size before delete
+                var itemOrderConnectionTableSize = mockContext.ItemOrderConnection.Count(); // itemorderconnection table size before delete
+                var timestampTableSize = mockContext.ItemTimestamp.Count(); // size of timestamp table before delete
 
                 // size of item list
-                var newConnection = mockContext.ItemOrderConnection.Where(ioc => ioc.OrderId == orderID).ToList();
+                var newConnection = mockContext.ItemOrderConnection.Where(ioc => ioc.OrderId == orderID).ToList();  // item order connections in order before delete
+                var oldTimestamps = new List<ItemTimestamp>();  // all old time stamps for all items in order
+                foreach (var item in newConnection)
+                {
+                    oldTimestamps.AddRange(mockContext.ItemTimestamp.Where(ts => ts.ItemId == item.ItemId).ToList());
+                }
 
                 //* Act
                 orderRepo.DeleteByOrderId(orderID);
 
                 //* Assert
-                Assert.AreEqual(orderTableSize - 1, mockContext.Order.Count());
-                Assert.AreEqual(itemTableSize - newConnection.Count, mockContext.Item.Count());
-                Assert.AreEqual(itemOrderConnectionTableSize - newConnection.Count, mockContext.ItemOrderConnection.Count());
+                Assert.AreEqual(orderTableSize - 1, mockContext.Order.Count());                 // removed 1 order
+                Assert.AreEqual(itemTableSize - newConnection.Count, mockContext.Item.Count()); // removed all items
+                Assert.AreEqual(itemOrderConnectionTableSize - newConnection.Count, mockContext.ItemOrderConnection.Count());   // removed all connections
+                Assert.AreEqual(timestampTableSize - oldTimestamps.Count, mockContext.ItemTimestamp.Count());                   // removed all timestamps
             }
         }
 

--- a/Bakendi/ThjonustukerfiWebAPI/Controllers/ItemController.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Controllers/ItemController.cs
@@ -107,9 +107,9 @@ namespace ThjonustukerfiWebAPI.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Route("statechangebyid")]
         [HttpPatch]
-        public IActionResult ChangeItemState([FromBody] List<ItemStateChangeInputModel> stateChanges)
+        public IActionResult ChangeItemStateById([FromBody] List<ItemStateChangeInputModel> stateChanges)
         {
-            _itemService.ChangeItemState(stateChanges);
+            _itemService.ChangeItemStateById(stateChanges);
 
             return Ok();
         }

--- a/Bakendi/ThjonustukerfiWebAPI/Controllers/ItemController.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Controllers/ItemController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ThjonustukerfiWebAPI.Models.InputModels;
@@ -97,6 +98,34 @@ namespace ThjonustukerfiWebAPI.Controllers
             _itemService.RemoveItemQuery(barcode);
 
             return NoContent();
+        }
+
+        /// <summary>Changes the state of all the items in the input. Takes in a list of ItemStateChangeInputModel.</summary>
+        /// <response code="200">All items have been updated</response>
+        /// <response code="404">Input was not valid</response>
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [Route("statechangebyid")]
+        [HttpPatch]
+        public IActionResult ChangeItemState([FromBody] List<ItemStateChangeInputModel> stateChanges)
+        {
+            _itemService.ChangeItemState(stateChanges);
+
+            return Ok();
+        }
+
+        /// <summary>Changes the state of all the items in the input. Takes in a list of ItemStateChangeInputModel.</summary>
+        /// <response code="200">All items have been updated</response>
+        /// <response code="404">Input was not valid</response>
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [Route("statechangebybarcode")]
+        [HttpPatch]
+        public IActionResult ChangeItemStateBarcode([FromBody] List<ItemStateChangeBarcodeInputModel> stateChanges)
+        {
+            _itemService.ChangeItemStateBarcode(stateChanges);
+
+            return Ok();
         }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Controllers/ItemController.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Controllers/ItemController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ThjonustukerfiWebAPI.Models.InputModels;
@@ -102,28 +103,34 @@ namespace ThjonustukerfiWebAPI.Controllers
 
         /// <summary>Changes the state of all the items in the input. Takes in a list of ItemStateChangeInputModel.</summary>
         /// <response code="200">All items have been updated</response>
-        /// <response code="404">Input was not valid</response>
+        /// <response code="202">Partial success, some inputs are invalid. A list of invalid inputs are returned.</response>
+        /// <response code="404">Input was not valid, no changes were made.</response>
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Route("statechangebyid")]
         [HttpPatch]
         public IActionResult ChangeItemStateById([FromBody] List<ItemStateChangeInputModel> stateChanges)
         {
-            _itemService.ChangeItemStateById(stateChanges);
+            var invalidInput = _itemService.ChangeItemStateById(stateChanges);
+
+            if(invalidInput.Any()) { return Accepted(invalidInput); }
 
             return Ok();
         }
 
         /// <summary>Changes the state of all the items in the input. Takes in a list of ItemStateChangeInputModel.</summary>
-        /// <response code="200">All items have been updated</response>
-        /// <response code="404">Input was not valid</response>
+        /// <response code="200">All items have been updated.</response>
+        /// <response code="202">Partial success, some inputs are invalid. A list of invalid inputs are returned.</response>
+        /// <response code="404">Input was not valid, no changes were made.</response>
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Route("statechangebybarcode")]
         [HttpPatch]
         public IActionResult ChangeItemStateBarcode([FromBody] List<ItemStateChangeBarcodeInputModel> stateChanges)
         {
-            _itemService.ChangeItemStateBarcode(stateChanges);
+            var invalidInput = _itemService.ChangeItemStateBarcode(stateChanges);
+
+            if(invalidInput.Any()) { return Accepted(invalidInput); }
 
             return Ok();
         }

--- a/Bakendi/ThjonustukerfiWebAPI/Extensions/ListExtensions.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Extensions/ListExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ThjonustukerfiWebAPI.Extensions
 {
@@ -15,6 +16,19 @@ namespace ThjonustukerfiWebAPI.Extensions
             foreach(var item in other)
             {
                 if(self.Contains(item)) { self.Remove(item); }
+            }
+        }
+
+        /// <summary>
+        ///     Adds item to list, only if it hasn't been added before
+        ///     
+        ///     Note that classes used in this method should have the all the Equals methods overrided to work.
+        /// </summary>
+        public static void AddIfUnique<T>(this IList<T> self, T other)
+        {
+            if(!self.Any() || !self.Contains(other))
+            {
+                self.Add(other);
             }
         }
     }

--- a/Bakendi/ThjonustukerfiWebAPI/Mappings/MappingProfile.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Mappings/MappingProfile.cs
@@ -61,6 +61,9 @@ namespace ThjonustukerfiWebAPI.Mappings
                 .ForMember(src => src.Id, opt => opt.Ignore())
                 .ForMember(src => src.TimeOfChange, opt => opt.MapFrom(src => DateTime.Now))
                 .AfterMap((src, dst) => { dst.ItemId = src.Id; });
+
+            //* ItemstateInput Mappings
+            CreateMap<ItemStateChangeInputModel, ItemStateChangeBarcodeInputModel>();
         }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Mappings/MappingProfile.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Mappings/MappingProfile.cs
@@ -58,7 +58,9 @@ namespace ThjonustukerfiWebAPI.Mappings
 
             //* ItemTimestamp Mappings
             CreateMap<Item, ItemTimestamp>()
-                .ForMember(src => src.TimeOfChange, opt => opt.MapFrom(src => DateTime.Now));
+                .ForMember(src => src.Id, opt => opt.Ignore())
+                .ForMember(src => src.TimeOfChange, opt => opt.MapFrom(src => DateTime.Now))
+                .AfterMap((src, dst) => { dst.ItemId = src.Id; });
         }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Mappings/MappingProfile.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Mappings/MappingProfile.cs
@@ -55,6 +55,10 @@ namespace ThjonustukerfiWebAPI.Mappings
             //* Category Mappings
             // Automapper for Category to CategoryDTO
             CreateMap<Category, CategoryDTO>();
+
+            //* ItemTimestamp Mappings
+            CreateMap<Item, ItemTimestamp>()
+                .ForMember(src => src.TimeOfChange, opt => opt.MapFrom(src => DateTime.Now));
         }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200414102611_itemTimestampTable.Designer.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200414102611_itemTimestampTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ThjonustukerfiWebAPI.Models;
@@ -9,9 +10,10 @@ using ThjonustukerfiWebAPI.Models;
 namespace ThjonustukerfiWebAPI.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20200414102611_itemTimestampTable")]
+    partial class itemTimestampTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -130,12 +132,15 @@ namespace ThjonustukerfiWebAPI.Migrations
                     b.ToTable("ItemOrderConnection");
                 });
 
-            modelBuilder.Entity("ThjonustukerfiWebAPI.Models.Entities.ItemTimestamp", b =>
+            modelBuilder.Entity("ThjonustukerfiWebAPI.Models.Entities.ItemTimeStamp", b =>
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint")
                         .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+                    b.Property<long>("ItemId")
+                        .HasColumnType("bigint");
 
                     b.Property<long>("StateId")
                         .HasColumnType("bigint");
@@ -145,7 +150,7 @@ namespace ThjonustukerfiWebAPI.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("ItemTimestamp");
+                    b.ToTable("ItemTimeStamp");
                 });
 
             modelBuilder.Entity("ThjonustukerfiWebAPI.Models.Entities.Log", b =>

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200414102611_itemTimestampTable.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200414102611_itemTimestampTable.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace ThjonustukerfiWebAPI.Migrations
+{
+    public partial class itemTimestampTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ItemTimeStamp",
+                columns: table => new
+                {
+                    Id = table.Column<long>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ItemId = table.Column<long>(nullable: false),
+                    StateId = table.Column<long>(nullable: false),
+                    TimeOfChange = table.Column<DateTime>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ItemTimeStamp", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ItemTimeStamp");
+        }
+    }
+}

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200414103503_typoInTable.Designer.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200414103503_typoInTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ThjonustukerfiWebAPI.Models;
@@ -9,9 +10,10 @@ using ThjonustukerfiWebAPI.Models;
 namespace ThjonustukerfiWebAPI.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20200414103503_typoInTable")]
+    partial class typoInTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200414103503_typoInTable.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200414103503_typoInTable.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ThjonustukerfiWebAPI.Migrations
+{
+    public partial class typoInTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ItemTimeStamp",
+                table: "ItemTimeStamp");
+
+            migrationBuilder.DropColumn(
+                name: "ItemId",
+                table: "ItemTimeStamp");
+
+            migrationBuilder.RenameTable(
+                name: "ItemTimeStamp",
+                newName: "ItemTimestamp");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ItemTimestamp",
+                table: "ItemTimestamp",
+                column: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ItemTimestamp",
+                table: "ItemTimestamp");
+
+            migrationBuilder.RenameTable(
+                name: "ItemTimestamp",
+                newName: "ItemTimeStamp");
+
+            migrationBuilder.AddColumn<long>(
+                name: "ItemId",
+                table: "ItemTimeStamp",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ItemTimeStamp",
+                table: "ItemTimeStamp",
+                column: "Id");
+        }
+    }
+}

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200414114632_addedItemIDinTimestampTable.Designer.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200414114632_addedItemIDinTimestampTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ThjonustukerfiWebAPI.Models;
@@ -9,9 +10,10 @@ using ThjonustukerfiWebAPI.Models;
 namespace ThjonustukerfiWebAPI.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20200414114632_addedItemIDinTimestampTable")]
+    partial class addedItemIDinTimestampTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Bakendi/ThjonustukerfiWebAPI/Migrations/20200414114632_addedItemIDinTimestampTable.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Migrations/20200414114632_addedItemIDinTimestampTable.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ThjonustukerfiWebAPI.Migrations
+{
+    public partial class addedItemIDinTimestampTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "ItemId",
+                table: "ItemTimestamp",
+                nullable: false,
+                defaultValue: 0L);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ItemId",
+                table: "ItemTimestamp");
+        }
+    }
+}

--- a/Bakendi/ThjonustukerfiWebAPI/Models/DTOs/ItemStateDTO.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/DTOs/ItemStateDTO.cs
@@ -7,6 +7,7 @@ namespace ThjonustukerfiWebAPI.Models.DTOs
     {
         public long Id { get; set; }
         public long OrderId { get; set; }
+        public string Service { get; set; }
         public string Category { get; set; }
         public string State { get; set; }
         public DateTime DateModified { get; set; }
@@ -18,7 +19,7 @@ namespace ThjonustukerfiWebAPI.Models.DTOs
 
             if(object.ReferenceEquals(is1, null) || object.ReferenceEquals(is2, null)) { return false; }
 
-            return is1.Id == is2.Id && is1.OrderId == is2.OrderId && is1.Category == is2.Category && is1.State == is2.State && is1.DateModified == is2.DateModified;
+            return is1.Id == is2.Id && is1.OrderId == is2.OrderId && is1.Category == is2.Category && is1.State == is2.State && is1.DateModified == is2.DateModified && is1.Service == is2.Service;
         }
 
         public static bool operator !=(ItemStateDTO is1, ItemStateDTO is2)

--- a/Bakendi/ThjonustukerfiWebAPI/Models/DataContext.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/DataContext.cs
@@ -16,6 +16,7 @@ namespace ThjonustukerfiWebAPI.Models
         public virtual DbSet<State> State { get; set; }
         public virtual DbSet<ServiceState> ServiceState { get; set; }
         public virtual DbSet<Category> Category { get; set; }
+        public virtual DbSet<ItemTimestamp> ItemTimestamp { get; set; }
 
         //* Error logs
         public virtual DbSet<Log> ExceptionLog { get; set; }

--- a/Bakendi/ThjonustukerfiWebAPI/Models/Entities/ItemTimestamp.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/Entities/ItemTimestamp.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace ThjonustukerfiWebAPI.Models.Entities
+{
+    public class ItemTimestamp
+    {
+        public long Id { get; set; }    // same as the item connected to it
+        public long StateId { get; set; }
+        public DateTime TimeOfChange { get; set; }
+    }
+}

--- a/Bakendi/ThjonustukerfiWebAPI/Models/Entities/ItemTimestamp.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/Entities/ItemTimestamp.cs
@@ -5,6 +5,7 @@ namespace ThjonustukerfiWebAPI.Models.Entities
     public class ItemTimestamp
     {
         public long Id { get; set; }    // same as the item connected to it
+        public long ItemId { get; set; }
         public long StateId { get; set; }
         public DateTime TimeOfChange { get; set; }
     }

--- a/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeBarcodeInputModel.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeBarcodeInputModel.cs
@@ -4,5 +4,47 @@ namespace ThjonustukerfiWebAPI.Models.InputModels
     {
         public string Barcode { get; set; }
         public long StateChangeTo { get; set; }
+
+        //*     Overrides     *//
+        public static bool operator ==(ItemStateChangeBarcodeInputModel i1, ItemStateChangeBarcodeInputModel i2)
+        {
+            if(object.ReferenceEquals(i1, i2))
+            {
+                return true;
+            }
+            if(object.ReferenceEquals(i1, null) || object.ReferenceEquals(i2, null))
+            {
+                return false;
+            }
+
+            return i1.Barcode == i2.Barcode && i1.StateChangeTo == i2.StateChangeTo;
+        }
+
+        public static bool operator !=(ItemStateChangeBarcodeInputModel i1, ItemStateChangeBarcodeInputModel i2)
+        {
+            return !(i1 == i2);
+        }
+
+        public override int GetHashCode()
+        {
+            int bc = 0;
+            foreach (char c in Barcode)
+            {
+                bc += c.GetHashCode();
+            }
+            bc += StateChangeTo.GetHashCode();
+            
+            return bc;
+        }
+
+        public bool Equals(ItemStateChangeBarcodeInputModel other)
+        {
+            return this == other;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ItemStateChangeBarcodeInputModel);
+        }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeBarcodeInputModel.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeBarcodeInputModel.cs
@@ -1,0 +1,8 @@
+namespace ThjonustukerfiWebAPI.Models.InputModels
+{
+    public class ItemStateChangeBarcodeInputModel
+    {
+        public string Barcode { get; set; }
+        public long StateChangeTo { get; set; }
+    }
+}

--- a/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeInputModel.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeInputModel.cs
@@ -5,5 +5,48 @@ namespace ThjonustukerfiWebAPI.Models.InputModels
         public long ItemId { get; set; }
         public string Barcode { get; set; }
         public long StateChangeTo { get; set; }
+
+        //*     Overrides     *//
+        public static bool operator ==(ItemStateChangeInputModel i1, ItemStateChangeInputModel i2)
+        {
+            if(object.ReferenceEquals(i1, i2))
+            {
+                return true;
+            }
+            if(object.ReferenceEquals(i1, null) || object.ReferenceEquals(i2, null))
+            {
+                return false;
+            }
+
+            return i1.Barcode == i2.Barcode && i1.StateChangeTo == i2.StateChangeTo && i1.ItemId == i2.ItemId;
+        }
+
+        public static bool operator !=(ItemStateChangeInputModel i1, ItemStateChangeInputModel i2)
+        {
+            return !(i1 == i2);
+        }
+
+        public override int GetHashCode()
+        {
+            int bc = 0;
+            foreach (char c in Barcode)
+            {
+                bc += c.GetHashCode();
+            }
+            bc += StateChangeTo.GetHashCode();
+            bc += ItemId.GetHashCode();
+            
+            return bc;
+        }
+
+        public bool Equals(ItemStateChangeInputModel other)
+        {
+            return this == other;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ItemStateChangeInputModel);
+        }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeInputModel.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeInputModel.cs
@@ -1,0 +1,8 @@
+namespace ThjonustukerfiWebAPI.Models.InputModels
+{
+    public class ItemStateChangeInputModel
+    {
+        public long ItemId { get; set; }
+        public long StateChangeTo { get; set; }
+    }
+}

--- a/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeInputModel.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeInputModel.cs
@@ -3,6 +3,7 @@ namespace ThjonustukerfiWebAPI.Models.InputModels
     public class ItemStateChangeInputModel
     {
         public long ItemId { get; set; }
+        public string Barcode { get; set; }
         public long StateChangeTo { get; set; }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
@@ -198,7 +198,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             if(orderId != -1) { SetOrderCompleteStatus(new List<long>() { orderId }); }
         }
 
-        public void ChangeItemState(List<ItemStateChangeInputModel> stateChanges)
+        public void ChangeItemStateById(List<ItemStateChangeInputModel> stateChanges)
         {
             //TODO: Ask, if the list is of size 100 and 2 or 1 have incorrect inputs, should this function update all that are correct or should it update none? As of now, updating none.
             // If this should be changed, just put the two forloops together and do not throw exception

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
+using ThjonustukerfiWebAPI.Extensions;
 using ThjonustukerfiWebAPI.Models;
 using ThjonustukerfiWebAPI.Models.DTOs;
 using ThjonustukerfiWebAPI.Models.Entities;
@@ -52,8 +54,9 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             var entity = _dbContext.Item.FirstOrDefault(i => i.Id == itemId);
             if(entity == null) { throw new NotFoundException($"Item with ID {itemId} was not found."); }
 
-            bool editState, editService, editOrder, editCategory;
-            editState = editService = editOrder = editCategory = false;
+            bool editState, editService, editOrder, editCategory, checkOrderComplete;
+            editState = editService = editOrder = editCategory = checkOrderComplete = false;
+            long orderID = -1;
 
             // finish all checks before editing anything, unfilled inputs will not be edited
             if(input.StateId != null)
@@ -91,6 +94,9 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 var timestamp = _dbContext.ItemTimestamp.FirstOrDefault(ts => ts.ItemId == entity.Id && ts.StateId == entity.StateId);
                 if(timestamp == null) { _dbContext.ItemTimestamp.Add(_mapper.Map<ItemTimestamp>(entity)); }
                 else { timestamp.TimeOfChange = DateTime.Now; }
+
+                orderID = _dbContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == itemId).OrderId;   // get the id of the connected order
+                checkOrderComplete = true;
             }
 
             // Update Service
@@ -116,6 +122,9 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             }
 
             _dbContext.SaveChanges();
+
+            //  If the state was changed, check if the order is complete
+            if(checkOrderComplete && orderID != -1) { SetOrderCompleteStatus(new List<long>() { orderID }); }
         }
 
         public long SearchItem(string search)
@@ -144,11 +153,14 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             else { timestamp.TimeOfChange = DateTime.Now; }
 
             // Update date modified of order connected to this
-            _dbContext.Order.FirstOrDefault(o =>
-                    o.Id == _dbContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == entity.Id).OrderId)  // find order connected to this item
-                        .DateModified = DateTime.Now;
+            var orderId = _dbContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == entity.Id).OrderId;
+
+            _dbContext.Order.FirstOrDefault(o => o.Id == orderId)
+                .DateModified = DateTime.Now;
 
             _dbContext.SaveChanges();
+
+            SetOrderCompleteStatus(new List<long>() { orderId });
         }
 
         public void RemoveItem(long itemId)
@@ -159,7 +171,12 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
 
             // Get connection and remove the connection
             var itemOrderConnection = _dbContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == entity.Id);
-            if(itemOrderConnection != null) { _dbContext.ItemOrderConnection.Remove(itemOrderConnection); }
+            long orderId = -1;
+            if(itemOrderConnection != null) 
+            {
+                _dbContext.ItemOrderConnection.Remove(itemOrderConnection);
+                orderId = itemOrderConnection.OrderId;
+            }
 
             // Get the timestamp and remove it
             var itemTimestamps = _dbContext.ItemTimestamp.Where(ts => ts.ItemId == entity.Id).ToList();
@@ -168,7 +185,90 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             // Remove entity
             _dbContext.Remove(entity);
 
+            // Update date modified of order connected to this
+            if(orderId != -1)
+            {
+                _dbContext.Order.FirstOrDefault(o => o.Id == orderId)
+                    .DateModified = DateTime.Now;
+            }
+
             _dbContext.SaveChanges();
+
+            // Check if the order is complete
+            if(orderId != -1) { SetOrderCompleteStatus(new List<long>() { orderId }); }
+        }
+
+        public void ChangeItemState(List<ItemStateChangeInputModel> stateChanges)
+        {
+            //TODO: Ask, if the list is of size 100 and 2 or 1 have incorrect inputs, should this function update all that are correct or should it update none? As of now, updating none.
+            // If this should be changed, just put the two forloops together and do not throw exception
+            foreach (var item in stateChanges)
+            {
+                // check if all item IDs are valid
+                if(_dbContext.Item.FirstOrDefault(i => i.Id == item.ItemId) == null) { throw new NotFoundException($"Item with ID {item.ItemId} was not found."); }
+
+                // check if all state changes are valid
+                if(_dbContext.State.FirstOrDefault(s => s.Id == item.StateChangeTo) == null) { throw new NotFoundException($"State with ID {item.StateChangeTo} was not found."); }
+            }
+
+            var ordersToCheck = new List<long>();
+
+            foreach (var item in stateChanges)
+            {
+                // get entity
+                var entity = _dbContext.Item.FirstOrDefault(i => i.Id == item.ItemId);
+
+                // update the entity itself
+                entity.StateId = item.StateChangeTo;
+                entity.DateModified = DateTime.Now;
+
+                // Update/create timestamp
+                var timeNow = DateTime.Now;
+                var timestamp = _dbContext.ItemTimestamp.FirstOrDefault(ts => ts.ItemId == entity.Id && ts.StateId == entity.StateId);
+                if(timestamp == null) { _dbContext.ItemTimestamp.Add(_mapper.Map<ItemTimestamp>(entity)); }
+                else { timestamp.TimeOfChange = timeNow; }
+
+                // add order ID if it has not been added before
+                ordersToCheck.AddIfUnique(_dbContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == item.ItemId).OrderId);
+            }
+
+            _dbContext.SaveChanges();
+
+            SetOrderCompleteStatus(ordersToCheck);
+        }
+
+        /// <summary>Sets all orders in list date completed, only if order is complete, else it sets it to null</summary>
+        private void SetOrderCompleteStatus(List<long> orders)
+        {
+            // check all order statuses
+            foreach (var order in orders)
+            {
+                var entity = _dbContext.Order.FirstOrDefault(o => o.Id == order);
+                if (IsOrderComplete(entity.Id)) { entity.DateCompleted = DateTime.Now; }
+                else { entity.DateCompleted = null; }
+            }
+
+            _dbContext.SaveChanges();
+        }
+
+        /// <summary>Checks if an order is complete</summary>
+        /// <returns>True if all items in order are in complete state</returns>
+        private bool IsOrderComplete(long orderId)
+        {
+            var entity = _dbContext.Order.FirstOrDefault(o => o.Id == orderId);
+            var connection = _dbContext.ItemOrderConnection.Where(ioc => ioc.OrderId == orderId).ToList();
+
+            // list is empty, return false
+            if(!connection.Any()) { return false; }
+
+            foreach (var item in connection)
+            {
+                //TODO: Change state done check to something else, like with other TODOs
+                // Return false if any item is not complete
+                if(_dbContext.Item.FirstOrDefault(i => i.Id == item.ItemId).StateId != 5) { return false; }
+            }
+
+            return true;
         }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
@@ -32,7 +32,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             stateDTO.OrderId = _dbContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == entity.Id).OrderId;   // get order ID
             stateDTO.State = _dbContext.State.FirstOrDefault(s => s.Id == entity.StateId).Name;                         // get state name
             stateDTO.Category = _dbContext.Category.FirstOrDefault(c => c.Id == entity.CategoryId).Name;                // get category name
-            stateDTO.Service = _dbContext.Service.FirstOrDefault(s => s.Id == entity.ServiceId).Name;
+            stateDTO.Service = _dbContext.Service.FirstOrDefault(s => s.Id == entity.ServiceId).Name;                   // get service name
 
             return stateDTO;
         }

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
@@ -32,6 +32,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             stateDTO.OrderId = _dbContext.ItemOrderConnection.FirstOrDefault(ioc => ioc.ItemId == entity.Id).OrderId;   // get order ID
             stateDTO.State = _dbContext.State.FirstOrDefault(s => s.Id == entity.StateId).Name;                         // get state name
             stateDTO.Category = _dbContext.Category.FirstOrDefault(c => c.Id == entity.CategoryId).Name;                // get category name
+            stateDTO.Service = _dbContext.Service.FirstOrDefault(s => s.Id == entity.ServiceId).Name;
 
             return stateDTO;
         }

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
@@ -206,7 +206,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
 
         }
 
-        //! Doesn't do SaveChanges(), rember to use save changes after calling this function
+        //! Doesn't do SaveChanges(), remember to use save changes after calling this function
         /// <summary>Used to add multiple items in order input</summary>
         private void AddMultipleItems(List<ItemInputModel> inpItems, long orderId)
         {
@@ -248,15 +248,19 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             // Get list connections
             var itemListConnections = _dbContext.ItemOrderConnection.Where(c => c.OrderId == entity.Id).ToList();
             
-            // Get all items in order
+            // Get all items in order and timestamp
             var itemList = new List<Item>();
+            var itemTimestamps = new List<ItemTimestamp>();
             foreach (var item in itemListConnections)
             {
                 itemList.Add(_dbContext.Item.FirstOrDefault(i => i.Id == item.ItemId));
+                itemTimestamps.Add(_dbContext.ItemTimestamp.FirstOrDefault(ts => ts.Id == item.ItemId));
             }
 
             // remove items
             if(itemList.Count > 0) { _dbContext.Item.RemoveRange(itemList); }
+            // remove timestamps
+            if(itemTimestamps.Count > 0) {  _dbContext.ItemTimestamp.RemoveRange(itemTimestamps); }
             // remove connections
             if(itemListConnections.Count > 0) { _dbContext.ItemOrderConnection.RemoveRange(itemListConnections); }
             // remove entity

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
@@ -163,7 +163,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 for( ; i < items.Count; i++)
                 {
                     itemListToDelete.Add(items[i]);
-                    timestampsToDelete.Add(_dbContext.ItemTimestamp.FirstOrDefault(ts => ts.Id == items[i].Id));    // Get timestamp with item
+                    timestampsToDelete.AddRange(_dbContext.ItemTimestamp.Where(ts => ts.ItemId == items[i].Id).ToList());    // Get timestamp with item
                 }
 
                 // get the connection table variables that connect the order with the items about to be removed
@@ -254,7 +254,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             foreach (var item in itemListConnections)
             {
                 itemList.Add(_dbContext.Item.FirstOrDefault(i => i.Id == item.ItemId));
-                itemTimestamps.Add(_dbContext.ItemTimestamp.FirstOrDefault(ts => ts.Id == item.ItemId));
+                itemTimestamps.Add(_dbContext.ItemTimestamp.FirstOrDefault(ts => ts.ItemId == item.ItemId));
             }
 
             // remove items
@@ -294,6 +294,12 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 itemToChange.StateId = 5;  //TODO: Same as in complete Item, update id to be more general (e.g. some global enunm or somthing)
                 itemToChange.DateCompleted = currentDate;
                 itemToChange.DateModified = currentDate;
+
+                // Update the timestamp
+                // state and item need to be the same else create a new timestamp
+                var timeStamp = _dbContext.ItemTimestamp.FirstOrDefault(ts => ts.ItemId == itemToChange.Id && ts.StateId == itemToChange.StateId);
+                if (timeStamp == null) { _dbContext.ItemTimestamp.Add(_mapper.Map<ItemTimestamp>(itemToChange)); }
+                else { timeStamp.TimeOfChange = currentDate; }
             }
 
             _dbContext.SaveChanges();

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
@@ -254,7 +254,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
             foreach (var item in itemListConnections)
             {
                 itemList.Add(_dbContext.Item.FirstOrDefault(i => i.Id == item.ItemId));
-                itemTimestamps.Add(_dbContext.ItemTimestamp.FirstOrDefault(ts => ts.ItemId == item.ItemId));
+                itemTimestamps.AddRange(_dbContext.ItemTimestamp.Where(ts => ts.ItemId == item.ItemId).ToList());
             }
 
             // remove items

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Interfaces/IItemRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Interfaces/IItemRepo.cs
@@ -26,6 +26,6 @@ namespace ThjonustukerfiWebAPI.Repositories.Interfaces
         void RemoveItem(long itemId);
 
         /// <summary>Changes the state of all items in the input with item ID</summary>
-        void ChangeItemState(List<ItemStateChangeInputModel> stateChanges);
+        void ChangeItemStateById(List<ItemStateChangeInputModel> stateChanges);
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Interfaces/IItemRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Interfaces/IItemRepo.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using ThjonustukerfiWebAPI.Models.DTOs;
 using ThjonustukerfiWebAPI.Models.InputModels;
 
@@ -23,5 +24,8 @@ namespace ThjonustukerfiWebAPI.Repositories.Interfaces
 
          /// <summary>Removes Item with the given ID</summary>
         void RemoveItem(long itemId);
+
+        /// <summary>Changes the state of all items in the input with item ID</summary>
+        void ChangeItemState(List<ItemStateChangeInputModel> stateChanges);
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Interfaces/IItemRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Interfaces/IItemRepo.cs
@@ -26,6 +26,6 @@ namespace ThjonustukerfiWebAPI.Repositories.Interfaces
         void RemoveItem(long itemId);
 
         /// <summary>Changes the state of all items in the input with item ID</summary>
-        void ChangeItemStateById(List<ItemStateChangeInputModel> stateChanges);
+        List<ItemStateChangeInputModel> ChangeItemStateById(List<ItemStateChangeInputModel> stateChanges);
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Services/Implementations/ItemService.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Services/Implementations/ItemService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using ThjonustukerfiWebAPI.Models.DTOs;
 using ThjonustukerfiWebAPI.Models.InputModels;
 using ThjonustukerfiWebAPI.Repositories.Interfaces;
@@ -22,5 +23,23 @@ namespace ThjonustukerfiWebAPI.Services.Implementations
         public void CompleteItem(long id) => _itemRepo.CompleteItem(id);
         public void RemoveItem(long itemId) => _itemRepo.RemoveItem(itemId);
         public void RemoveItemQuery(string barcode) => _itemRepo.RemoveItem(_itemRepo.SearchItem(barcode));
+        public void ChangeItemState(List<ItemStateChangeInputModel> stateChanges) { _itemRepo.ChangeItemState(stateChanges); }
+        public void ChangeItemStateBarcode(List<ItemStateChangeBarcodeInputModel> stateChanges)
+        {
+            // create list with IDs in stead of barcode
+            var stateChangesWithId = new List<ItemStateChangeInputModel>();
+            foreach (var change in stateChanges)
+            {
+                // add with correct ID
+                stateChangesWithId.Add(new ItemStateChangeInputModel
+                {
+                    ItemId = _itemRepo.SearchItem(change.Barcode),
+                    StateChangeTo = change.StateChangeTo
+                });
+            }
+
+            // update the items
+            _itemRepo.ChangeItemState(stateChangesWithId);
+        }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Services/Implementations/ItemService.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Services/Implementations/ItemService.cs
@@ -23,7 +23,7 @@ namespace ThjonustukerfiWebAPI.Services.Implementations
         public void CompleteItem(long id) => _itemRepo.CompleteItem(id);
         public void RemoveItem(long itemId) => _itemRepo.RemoveItem(itemId);
         public void RemoveItemQuery(string barcode) => _itemRepo.RemoveItem(_itemRepo.SearchItem(barcode));
-        public void ChangeItemState(List<ItemStateChangeInputModel> stateChanges) { _itemRepo.ChangeItemState(stateChanges); }
+        public void ChangeItemStateById(List<ItemStateChangeInputModel> stateChanges) { _itemRepo.ChangeItemStateById(stateChanges); }
         public void ChangeItemStateBarcode(List<ItemStateChangeBarcodeInputModel> stateChanges)
         {
             // create list with IDs in stead of barcode
@@ -39,7 +39,7 @@ namespace ThjonustukerfiWebAPI.Services.Implementations
             }
 
             // update the items
-            _itemRepo.ChangeItemState(stateChangesWithId);
+            _itemRepo.ChangeItemStateById(stateChangesWithId);
         }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Services/Implementations/ItemService.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Services/Implementations/ItemService.cs
@@ -23,7 +23,7 @@ namespace ThjonustukerfiWebAPI.Services.Implementations
         public void CompleteItem(long id) => _itemRepo.CompleteItem(id);
         public void RemoveItem(long itemId) => _itemRepo.RemoveItem(itemId);
         public void RemoveItemQuery(string barcode) => _itemRepo.RemoveItem(_itemRepo.SearchItem(barcode));
-        public void ChangeItemStateById(List<ItemStateChangeInputModel> stateChanges) { _itemRepo.ChangeItemStateById(stateChanges); }
+        public void ChangeItemStateById(List<ItemStateChangeInputModel> stateChanges) => _itemRepo.ChangeItemStateById(stateChanges);
         public void ChangeItemStateBarcode(List<ItemStateChangeBarcodeInputModel> stateChanges)
         {
             // create list with IDs in stead of barcode

--- a/Bakendi/ThjonustukerfiWebAPI/Services/Interfaces/IItemService.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Services/Interfaces/IItemService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using ThjonustukerfiWebAPI.Models.DTOs;
 using ThjonustukerfiWebAPI.Models.InputModels;
 
@@ -24,5 +25,11 @@ namespace ThjonustukerfiWebAPI.Services.Interfaces
 
         /// <summary>Removes item with the given barcode</summary>
         void RemoveItemQuery(string barcode);
+
+        /// <summary>Changes the state of all items in the input with item ID</summary>
+        void ChangeItemState(List<ItemStateChangeInputModel> stateChanges);
+
+        /// <summary>Changes the state of all items in the input with item barcode"</summary>
+        void ChangeItemStateBarcode(List<ItemStateChangeBarcodeInputModel> stateChanges);
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Services/Interfaces/IItemService.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Services/Interfaces/IItemService.cs
@@ -27,9 +27,11 @@ namespace ThjonustukerfiWebAPI.Services.Interfaces
         void RemoveItemQuery(string barcode);
 
         /// <summary>Changes the state of all items in the input with item ID</summary>
-        void ChangeItemStateById(List<ItemStateChangeInputModel> stateChanges);
+        /// <returns>List of inputs that are not correct and did not update, if any</returns>
+        List<ItemStateChangeInputModel> ChangeItemStateById(List<ItemStateChangeInputModel> stateChanges);
 
         /// <summary>Changes the state of all items in the input with item barcode"</summary>
-        void ChangeItemStateBarcode(List<ItemStateChangeBarcodeInputModel> stateChanges);
+        /// <returns>List of inputs that are not correct and did not update, if any</returns>
+        List<ItemStateChangeBarcodeInputModel> ChangeItemStateBarcode(List<ItemStateChangeBarcodeInputModel> stateChanges);
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Services/Interfaces/IItemService.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Services/Interfaces/IItemService.cs
@@ -27,7 +27,7 @@ namespace ThjonustukerfiWebAPI.Services.Interfaces
         void RemoveItemQuery(string barcode);
 
         /// <summary>Changes the state of all items in the input with item ID</summary>
-        void ChangeItemState(List<ItemStateChangeInputModel> stateChanges);
+        void ChangeItemStateById(List<ItemStateChangeInputModel> stateChanges);
 
         /// <summary>Changes the state of all items in the input with item barcode"</summary>
         void ChangeItemStateBarcode(List<ItemStateChangeBarcodeInputModel> stateChanges);


### PR DESCRIPTION
Eins og síðast verðið þið að gera: dotnet ef database update

Service núna sýnilegt í ItemStateDTO

Það er hægt að uppfæra stöðu vöru, bæði með barcode og ID. Eingöngu vitlaus input eru skiluð til baka (ef einhver) með status kóða 202 Accepted. Ef allt virkar fínt þá er 200 OK skilað.

Hvert skipti sem Item er uppfært er tjekk hvort að samsvarandi order sé búið, ef svo, er datecomplete með gildi, annars verður það null.

Allar stöður eru núna með stöðufærslu. Ekki komið functionality til að sækja stöðufærslur en þær eru svo sannarlega til staðar í gagnagrunninum :)
