### PR TITLE
Editchangestate bak

### DIFF
--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemControllerTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemControllerTests.cs
@@ -178,13 +178,13 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             //* Arrange
             var input = new List<ItemStateChangeInputModel>()
             {
-                new ItemStateChangeInputModel { ItemId = -1, StateChangeTo = -1 },
-                new ItemStateChangeInputModel { ItemId = 1, StateChangeTo = 2 }
+                new ItemStateChangeInputModel { ItemId = -1, StateChangeBarcode = @"Í Vinnslu-{location:""hilla1A""}" },
+                new ItemStateChangeInputModel { ItemId = 1, StateChangeBarcode = @"Kælir1-{location:""hilla1A""}" }
             };
 
             var invalidInputs = new List<ItemStateChangeInputModel>()
             {
-                new ItemStateChangeInputModel { ItemId = -1, StateChangeTo = -1 }
+                new ItemStateChangeInputModel { ItemId = -1, StateChangeBarcode = @"Í Vinnslu-{location:""hilla1A""}" }
             };
 
             // Mock service
@@ -229,13 +229,13 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             //* Arrange
             var input = new List<ItemStateChangeBarcodeInputModel>()
             {
-                new ItemStateChangeBarcodeInputModel { Barcode = "-1", StateChangeTo = -1 },
-                new ItemStateChangeBarcodeInputModel { Barcode = "983764892374", StateChangeTo = 2 }
+                new ItemStateChangeBarcodeInputModel { ItemBarcode = "-1", StateChangeBarcode = @"Í Vinnslu-{location:""hilla1A""}" },
+                new ItemStateChangeBarcodeInputModel { ItemBarcode = "983764892374", StateChangeBarcode = @"Kælir1-{location:""hilla1A""}" }
             };
             
             var invalidInputs = new List<ItemStateChangeBarcodeInputModel>()
             {
-                new ItemStateChangeBarcodeInputModel { Barcode = "-1", StateChangeTo = -1 }
+                new ItemStateChangeBarcodeInputModel { ItemBarcode = "-1", StateChangeBarcode = @"Kælir1-{location:""hilla1A""}" }
             };
 
             // Mock service

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemRepoTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemRepoTests.cs
@@ -368,21 +368,23 @@ namespace ThjonustukerfiTests.Tests.ItemTests
         public void ChangeItemStateById_should_change_state_of_item_to_2_and_order_connected_to_it_should_not_have_completeDate()
         {
             //* Arrange
-            long itemId = 2;
-            long stateChange = 2;
-
-            var input = new List<ItemStateChangeInputModel>()
-            {
-                new ItemStateChangeInputModel
-                {
-                    ItemId = itemId,
-                    StateChangeTo = stateChange
-                }
-            };
-
-            // This item is the only Item in the order at this moment
             using(var mockContext = new DataContext(_options))
             {
+                // This item is the only Item in the order at this moment
+                long itemId = 2;
+                long statechangeID = 2;
+                // constructing the barcode string
+                string stateChange = $"{mockContext.State.FirstOrDefault(s => s.Id == statechangeID).Name}" + @"-{location:""hilla1A""}";
+
+                var input = new List<ItemStateChangeInputModel>()
+                {
+                    new ItemStateChangeInputModel
+                    {
+                        ItemId = itemId,
+                        StateChangeBarcode = stateChange
+                    }
+                };
+
                 IItemRepo itemRepo = new ItemRepo(mockContext, _mapper);
 
                 // Get old state
@@ -396,7 +398,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
 
                 Assert.IsNotNull(item);
                 Assert.AreNotEqual(oldItemState, item.StateId);
-                Assert.AreEqual(stateChange, item.StateId);
+                Assert.AreEqual(statechangeID, item.StateId);
 
                 // check order connected
                 var order = mockContext.Order.FirstOrDefault(o =>
@@ -411,21 +413,24 @@ namespace ThjonustukerfiTests.Tests.ItemTests
         public void ChangeItemStateById_should_change_state_of_item_to_5_and_order_connected_to_it_should_have_completeDate()
         {
             //* Arrange
-            long itemId = 2;
-            long stateChange = 5;
 
-            var input = new List<ItemStateChangeInputModel>()
-            {
-                new ItemStateChangeInputModel
-                {
-                    ItemId = itemId,
-                    StateChangeTo = stateChange
-                }
-            };
-
-            // This item is the only Item in the order at this moment
             using(var mockContext = new DataContext(_options))
             {
+                // This item is the only Item in the order at this moment
+                long itemId = 2;
+                long statechangeID = 5;
+                // Create the barcode string
+                string stateChange = $"{mockContext.State.FirstOrDefault(s => s.Id == statechangeID).Name}" + @"-{location:""hilla1A""}";
+
+                var input = new List<ItemStateChangeInputModel>()
+                {
+                    new ItemStateChangeInputModel
+                    {
+                        ItemId = itemId,
+                        StateChangeBarcode = stateChange
+                    }
+                };
+
                 IItemRepo itemRepo = new ItemRepo(mockContext, _mapper);
 
                 // get old state
@@ -439,7 +444,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
 
                 Assert.IsNotNull(item);
                 Assert.AreNotEqual(oldItemState, item.StateId);
-                Assert.AreEqual(stateChange, item.StateId);
+                Assert.AreEqual(statechangeID, item.StateId);
 
                 // check order connected
                 var order = mockContext.Order.FirstOrDefault(o =>
@@ -455,23 +460,24 @@ namespace ThjonustukerfiTests.Tests.ItemTests
         {
             //* Arrange
             long invalidId = -1;
-            long invalidState = -1;
+            string invalidState = @"Í Vinnslu-{location:""hilla1A""}";
+
             long validId = 2;
-            long validState = 5;
+            string validState = @"Sótt-{location:""hilla1A""}";
 
             // The input with valid and invalid variables
             var input = new List<ItemStateChangeInputModel>()
             {
-                new ItemStateChangeInputModel { ItemId = invalidId, StateChangeTo = validState },
-                new ItemStateChangeInputModel { ItemId = validId, StateChangeTo = invalidState },
-                new ItemStateChangeInputModel { ItemId = validId, StateChangeTo = validState }
+                new ItemStateChangeInputModel { ItemId = invalidId, StateChangeBarcode = validState },
+                new ItemStateChangeInputModel { ItemId = validId, StateChangeBarcode = invalidState },
+                new ItemStateChangeInputModel { ItemId = validId, StateChangeBarcode = validState }
             };
 
             // Expected return from the function
             var expectedReturn = new List<ItemStateChangeInputModel>()
             {
-                new ItemStateChangeInputModel { ItemId = invalidId, StateChangeTo = validState },
-                new ItemStateChangeInputModel { ItemId = validId, StateChangeTo = invalidState }
+                new ItemStateChangeInputModel { ItemId = invalidId, StateChangeBarcode = validState },
+                new ItemStateChangeInputModel { ItemId = validId, StateChangeBarcode = invalidState }
             };
 
             using(var mockContext = new DataContext(_options))
@@ -496,12 +502,12 @@ namespace ThjonustukerfiTests.Tests.ItemTests
         {
             //* Arrange
             long validId = 2;
-            long validState = 5;
+            string validState = @"Sótt-{location:""hilla1A""}";
 
             // The input with valid and invalid variables
             var input = new List<ItemStateChangeInputModel>()
             {
-                new ItemStateChangeInputModel { ItemId = validId, StateChangeTo = validState }
+                new ItemStateChangeInputModel { ItemId = validId, StateChangeBarcode = validState }
             };
 
             using(var mockContext = new DataContext(_options))
@@ -523,11 +529,11 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             //* Arrange
             var input1 = new List<ItemStateChangeInputModel>()
             {
-                new ItemStateChangeInputModel { ItemId = -1, StateChangeTo = 2 }
+                new ItemStateChangeInputModel { ItemId = -1, StateChangeBarcode = @"Kælir1-{location:""hilla1A""}" }
             };
             var input2 = new List<ItemStateChangeInputModel>()
             {
-                new ItemStateChangeInputModel { ItemId = 2, StateChangeTo = -1 }
+                new ItemStateChangeInputModel { ItemId = 2, StateChangeBarcode = @"Í Vinnslu-{location:""hilla1A""}" }
             };
 
             using(var mockContext = new DataContext(_options))
@@ -672,6 +678,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
                     StateId = 1,
                     ServiceId = 1,
                     Barcode = "50500001",
+                    JSON = @"{location:""Vinnslu""}",
                     DateCreated = DateTime.MinValue,
                     DateModified = DateTime.Now,
                     DateCompleted = DateTime.MaxValue
@@ -683,6 +690,7 @@ namespace ThjonustukerfiTests.Tests.ItemTests
                     StateId = 1,
                     ServiceId = 1,
                     Barcode = "50500002",
+                    JSON = @"{location:""Vinnslu""}",
                     DateCreated = DateTime.MinValue,
                     DateModified = DateTime.Now,
                     DateCompleted = DateTime.MaxValue
@@ -756,9 +764,9 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             var states = new List<State>()
             {
                 // states fyrir Reykofninn
-                new State() {Name = "Í vinnslu", Id = 1},
-                new State() {Name = "Kælir 1", Id = 2},
-                new State() {Name = "Kælir 2", Id = 3},
+                new State() {Name = "Vinnslu", Id = 1},
+                new State() {Name = "Kælir1", Id = 2},
+                new State() {Name = "Kælir2", Id = 3},
                 new State() {Name = "Frystir", Id = 4},
                 new State() {Name = "Sótt", Id = 5}
             };

--- a/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemServiceTests.cs
+++ b/Bakendi/ThjonustukerfiTests/Tests/ItemTests/ItemServiceTests.cs
@@ -98,13 +98,13 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             //* Arrange
             var input = new List<ItemStateChangeBarcodeInputModel>()
             {
-                new ItemStateChangeBarcodeInputModel { Barcode = invalidbarcode, StateChangeTo = 1 },
-                new ItemStateChangeBarcodeInputModel { Barcode = validBarcode, StateChangeTo = 2 }
+                new ItemStateChangeBarcodeInputModel { ItemBarcode = invalidbarcode, StateChangeBarcode = @"Vinnslu-{location:""hilla1A""}" },
+                new ItemStateChangeBarcodeInputModel { ItemBarcode = validBarcode, StateChangeBarcode = @"Kælir1-{location:""hilla1A""}" }
             };
             
             var invalidInputs = new List<ItemStateChangeBarcodeInputModel>()
             {
-                new ItemStateChangeBarcodeInputModel { Barcode = invalidbarcode, StateChangeTo = 1 }
+                new ItemStateChangeBarcodeInputModel { ItemBarcode = invalidbarcode, StateChangeBarcode = @"Vinnslu-{location:""hilla1A""}" }
             };
 
             // Mock Repo
@@ -133,8 +133,8 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             //* Arrange
             var input = new List<ItemStateChangeBarcodeInputModel>()
             {
-                new ItemStateChangeBarcodeInputModel { Barcode = validBarcode, StateChangeTo = 1 },
-                new ItemStateChangeBarcodeInputModel { Barcode = validBarcode2, StateChangeTo = 2 }
+                new ItemStateChangeBarcodeInputModel { ItemBarcode = validBarcode, StateChangeBarcode = @"Vinnslu-{location:""hilla1A""}" },
+                new ItemStateChangeBarcodeInputModel { ItemBarcode = validBarcode2, StateChangeBarcode = @"Kælir1-{location:""hilla1A""}" }
             };
 
             // Mock Repo
@@ -161,8 +161,8 @@ namespace ThjonustukerfiTests.Tests.ItemTests
             //* Arrange
             var input = new List<ItemStateChangeInputModel>()
             {
-                new ItemStateChangeInputModel { ItemId = validId, StateChangeTo = 1 },
-                new ItemStateChangeInputModel { ItemId = validId2, StateChangeTo = 2 }
+                new ItemStateChangeInputModel { ItemId = validId, StateChangeBarcode = @"Vinnslu-{location:""hilla1A""}" },
+                new ItemStateChangeInputModel { ItemId = validId2, StateChangeBarcode = @"Kælir1-{location:""hilla1A""}" }
             };
 
             // Mock Repo

--- a/Bakendi/ThjonustukerfiWebAPI/Configurations/SetupTables.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Configurations/SetupTables.cs
@@ -20,7 +20,6 @@ namespace ThjonustukerfiWebAPI.Configurations
         }
 
         // setup Service
-        //TODO: Add remove?
         public void Run()
         {
             var DB_Services = _dbContext.Set<Service>().ToList();
@@ -32,36 +31,48 @@ namespace ThjonustukerfiWebAPI.Configurations
             bool change = false;
 
             // empty or not with all data
-            if(DB_Services == null || DB_Services.Count == 0 || DB_Services.Count != _services.Count)
+            if(DB_Services == null || DB_Services.Count == 0 || !_services.ContainsSameElements(DB_Services))
             {
-                _services.RemoveExisting(DB_Services);
+                var removeItems = _services.GetNotSame(DB_Services);    // check if any services have been removed from the config
+                if(removeItems.Count > 0) { _dbContext.Service.RemoveRange(removeItems); }  // if so remove those services
+
+                _services.RemoveExisting(DB_Services);      // Removes all services that are the same so we only add new services
                 _dbContext.Service.AddRange(_services);
 
                 change = true;
             }
 
             // empty or not with all data
-            if(DB_ServiceStates == null || DB_ServiceStates.Count == 0 || DB_ServiceStates.Count != _serviceStates.Count)
+            if(DB_ServiceStates == null || DB_ServiceStates.Count == 0 || !_serviceStates.ContainsSameElements(DB_ServiceStates))
             {
-                _serviceStates.RemoveExisting(DB_ServiceStates);
+                var removeItems = _serviceStates.GetNotSame(DB_ServiceStates);  // check if any service states have been removed from the config
+                if(removeItems.Count > 0) { _dbContext.ServiceState.RemoveRange(removeItems); } // if so, remove them
+
+                _serviceStates.RemoveExisting(DB_ServiceStates);    // Removes all servicestates that are the same so we only add new service states
                 _dbContext.ServiceState.AddRange(_serviceStates);
 
                 change = true;
             }
             
             // empty or not with all data
-            if(DB_States == null || DB_States.Count == 0 || DB_States.Count != _states.Count)
+            if(DB_States == null || DB_States.Count == 0 || !_states.ContainsSameElements(DB_States))
             {
-                _states.RemoveExisting(DB_States);
+                var removeItems = _states.GetNotSame(DB_States);    // checks if any States have been removed from the config
+                if(removeItems.Count > 0) { _dbContext.State.RemoveRange(removeItems); }    // if so, remove them
+
+                _states.RemoveExisting(DB_States);  // Removes all states that are the same so we only add new service states
                 _dbContext.State.AddRange(_states);
 
                 change = true;
             }
 
             // empty or not with all data
-            if(DB_Categories == null || DB_Categories.Count == 0 || DB_Categories.Count != _states.Count)
+            if(DB_Categories == null || DB_Categories.Count == 0 || !_categories.ContainsSameElements(DB_Categories))
             {
-                _categories.RemoveExisting(DB_Categories);
+                var removeItems = _categories.GetNotSame(DB_Categories);    // checks if any categories have benn removed from the config
+                if(removeItems.Count > 0) { _dbContext.Category.RemoveRange(removeItems); } // if so, remove them
+
+                _categories.RemoveExisting(DB_Categories);  // Removes all categories that are the same so we only add new categories
                 _dbContext.Category.AddRange(_categories);
 
                 change = true;
@@ -119,9 +130,9 @@ namespace ThjonustukerfiWebAPI.Configurations
             _states = new List<State>()
             {
                 // states fyrir Reykofninn
-                new State() {Name = "Í vinnslu", Id = 1},
-                new State() {Name = "Kælir 1", Id = 2},
-                new State() {Name = "Kælir 2", Id = 3},
+                new State() {Name = "Vinnslu", Id = 1},
+                new State() {Name = "Kælir1", Id = 2},
+                new State() {Name = "Kælir2", Id = 3},
                 new State() {Name = "Frystir", Id = 4},
                 new State() {Name = "Sótt", Id = 5}
             };

--- a/Bakendi/ThjonustukerfiWebAPI/Extensions/ListExtensions.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Extensions/ListExtensions.cs
@@ -31,5 +31,51 @@ namespace ThjonustukerfiWebAPI.Extensions
                 self.Add(other);
             }
         }
+
+        /// <summary>
+        ///     Gets all the elements in other that are not in itself.
+        ///     
+        ///     Note that classes used in this method should have the all the Equals methods overrided to work.
+        /// </summary>
+        /// <returns>
+        ///     Returns a list of elements in other that are not in itself. Empty list if self contains all items in other.
+        /// </returns>
+        public static List<T> GetNotSame<T>(this IList<T> self, IEnumerable<T> other)
+        {
+            var newList = new List<T>();
+
+            foreach (var otheritem in other)
+            {
+                if(!self.Contains(otheritem))
+                {
+                    newList.Add(otheritem);
+                }
+            }
+
+            return newList;
+        }
+
+        /// <summary>
+        ///     Checks if the lists contain exactly the same elements.
+        ///     
+        ///     Note that classes used in this method should have the all the Equals methods overrided to work.
+        /// </summary>
+        /// <returns>
+        ///     Returns True if lists are the same. False if not.
+        /// </returns>
+        public static bool ContainsSameElements<T>(this IList<T> self, IEnumerable<T> other)
+        {
+            if(self.Count != other.Count()) { return false; }   // list are not same size, return false
+
+            foreach (var otheritem in other)
+            {
+                if(!self.Contains(otheritem))   // If the item is not in self, return false
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/Bakendi/ThjonustukerfiWebAPI/Models/DTOs/ItemDTO.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/DTOs/ItemDTO.cs
@@ -8,6 +8,7 @@ namespace ThjonustukerfiWebAPI.Models.DTOs
         public string Service { get; set; }
         public string State { get; set; }
         public string Barcode { get; set; }
+        public string JSON { get; set; }
 
         //*     Overrides     *//
         public static bool operator ==(ItemDTO i1, ItemDTO i2)

--- a/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeBarcodeInputModel.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeBarcodeInputModel.cs
@@ -1,10 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace ThjonustukerfiWebAPI.Models.InputModels
 {
     /// <summary>Input model used to change the state of an item by barcode.</summary>
     public class ItemStateChangeBarcodeInputModel
     {
-        public string Barcode { get; set; }
-        public long StateChangeTo { get; set; }
+        [Required]
+        public string ItemBarcode { get; set; }
+        [Required]
+        public string StateChangeBarcode { get; set; }
 
         //*     Overrides     *//
         public static bool operator ==(ItemStateChangeBarcodeInputModel i1, ItemStateChangeBarcodeInputModel i2)
@@ -18,7 +22,7 @@ namespace ThjonustukerfiWebAPI.Models.InputModels
                 return false;
             }
 
-            return i1.Barcode == i2.Barcode && i1.StateChangeTo == i2.StateChangeTo;
+            return i1.ItemBarcode == i2.ItemBarcode && i1.StateChangeBarcode == i2.StateChangeBarcode;
         }
 
         public static bool operator !=(ItemStateChangeBarcodeInputModel i1, ItemStateChangeBarcodeInputModel i2)
@@ -29,11 +33,14 @@ namespace ThjonustukerfiWebAPI.Models.InputModels
         public override int GetHashCode()
         {
             int bc = 0;
-            foreach (char c in Barcode)
+            foreach (char c in ItemBarcode)
             {
                 bc += c.GetHashCode();
             }
-            bc += StateChangeTo.GetHashCode();
+            foreach (char c in StateChangeBarcode)
+            {
+                bc += c.GetHashCode();
+            }
             
             return bc;
         }

--- a/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeInputModel.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Models/InputModels/ItemStateChangeInputModel.cs
@@ -1,11 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace ThjonustukerfiWebAPI.Models.InputModels
 {
     /// <summary>Input model used to change the state of an item by ID.</summary>
     public class ItemStateChangeInputModel
     {
-        public long ItemId { get; set; }
-        public string Barcode { get; set; }
-        public long StateChangeTo { get; set; }
+        [Required]
+        public long? ItemId { get; set; }
+        [Required]
+        public string StateChangeBarcode { get; set; }
 
         //*     Overrides     *//
         public static bool operator ==(ItemStateChangeInputModel i1, ItemStateChangeInputModel i2)
@@ -19,7 +22,7 @@ namespace ThjonustukerfiWebAPI.Models.InputModels
                 return false;
             }
 
-            return i1.Barcode == i2.Barcode && i1.StateChangeTo == i2.StateChangeTo && i1.ItemId == i2.ItemId;
+            return i1.StateChangeBarcode == i2.StateChangeBarcode && i1.ItemId == i2.ItemId;
         }
 
         public static bool operator !=(ItemStateChangeInputModel i1, ItemStateChangeInputModel i2)
@@ -30,11 +33,10 @@ namespace ThjonustukerfiWebAPI.Models.InputModels
         public override int GetHashCode()
         {
             int bc = 0;
-            foreach (char c in Barcode)
+            foreach (char c in StateChangeBarcode)
             {
                 bc += c.GetHashCode();
             }
-            bc += StateChangeTo.GetHashCode();
             bc += ItemId.GetHashCode();
             
             return bc;

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/ItemRepo.cs
@@ -233,10 +233,13 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 entity.DateModified = DateTime.Now;
 
                 // Get the json object and change it and write it back (making sure only to change the location property if there are any other properties there)
-                JObject rss = JObject.Parse(entity.JSON);   // parse the entity
-                var prop = rss.Property("location").Value;  // get the location property
-                prop = parsedBarcode[1];                    // set the location
-                entity.JSON = prop.ToString();              // serialize back to string
+                if(entity.JSON != null)
+                {
+                    JObject rss = JObject.Parse(entity.JSON);   // parse the entity
+                    var prop = rss.Property("location").Value;  // get the location property
+                    prop = parsedBarcode[1];                    // set the location
+                    entity.JSON = prop.ToString();              // serialize back to string
+                }
 
                 // Update/create timestamp
                 var timeNow = DateTime.Now;

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Implementations/OrderRepo.cs
@@ -222,6 +222,7 @@ namespace ThjonustukerfiWebAPI.Repositories.Implementations
                 var itemToAdd = _mapper.Map<Item>(item);
                 itemToAdd.Id = newItemId;
                 itemToAdd.Barcode = newItemBarcode.ToString();
+                itemToAdd.JSON = @"{location: ""Vinnslu""}";
                 _dbContext.Item.Add(itemToAdd);
 
                 // Create Timestamp

--- a/Bakendi/ThjonustukerfiWebAPI/Repositories/Interfaces/IItemRepo.cs
+++ b/Bakendi/ThjonustukerfiWebAPI/Repositories/Interfaces/IItemRepo.cs
@@ -33,5 +33,9 @@ namespace ThjonustukerfiWebAPI.Repositories.Interfaces
         /// <summary>Gets the item entity by ID.</summary>
         /// <returns>Item entity.</returns>
         Item GetItemEntity(long id);
+
+        /// <summary>Gets the items barcode with given ID</summary>
+        /// <returns>Barcode in string format</returns>
+        string GetItemBarcodeById(long id);
     }
 }


### PR DESCRIPTION
Setup tables that runs after build is complete will now remove elements from tables if they are not in the "config".

Now when updating states you can send in itemID or ItemBarcode as before but the state change is now represented as a barcode, eg. Kælir1-{location:Hilla2d}
The API will parse this barcode so that it updates correct entities.

I REALLY recommend you remove all items from Item tables to be able to see these new changes. easiest way to do it would be to remove all orders: api/orders/<orderid> as a DELETE request